### PR TITLE
Track project context in-repo: CLAUDE.md + sp_validation fibers

### DIFF
--- a/.felt/cat-config-sp-v1-5-4-missing-psf/cat-config-sp-v1-5-4-missing-psf.md
+++ b/.felt/cat-config-sp-v1-5-4-missing-psf/cat-config-sp-v1-5-4-missing-psf.md
@@ -1,0 +1,10 @@
+---
+name: 'cat_config: SP_v1.5.4 missing PSF file'
+status: closed
+tags:
+    - data
+    - catalog
+created-at: 2026-06-03T10:59:39.118309714+02:00
+closed-at: 2026-06-04T00:47:15.280965453+02:00
+outcome: 'Dropped SP_v1.5.4 from cat_config.yaml. Root cause: the shared v1.5.a PSF catalog was never finalized — only unions_shapepipe_psf_2024_v1.5.a_prev.fits exists on disk (the sibling v1.6.a was regenerated Jan 11, v1.5.a was not). Shear catalog + v1.5.4/ dir are fine; only PSF missing. Non-fiducial version (we''re v1.4.6.3); only consumed by plot_footprints.py (builds paths directly, doesn''t read cat_config) and stale plot_comparison.ipynb output cells — no live consumer breaks. test_catalog_paths_exist now passes on cluster.'
+---

--- a/.felt/docker-build-uv-venv-base/docker-build-uv-venv-base.md
+++ b/.felt/docker-build-uv-venv-base/docker-build-uv-venv-base.md
@@ -1,0 +1,54 @@
+---
+name: 'Docker build: uv-venv base image'
+tags:
+    - docker
+    - ci
+created-at: 2026-06-03T10:22:53.245547768+02:00
+outcome: 'shapepipe:develop (moving tag) switched to a uv venv at /app/.venv and dropped libtool, breaking the sp_validation image two ways; fixed in Dockerfile by adding autotools + using uv pip. Recurring risk: the base tag moves.'
+---
+
+The `Dockerfile` builds `FROM ghcr.io/cosmostat/shapepipe:develop` — a **moving tag**.
+A rebuild of that upstream image on 2026-05-31 changed the environment underneath us, and
+the GitHub Actions "Create and publish a Docker image" workflow went red. The same
+`sp_validation` code built green on 2026-05-04. Two independent breakages, fixed in two
+commits on `develop`:
+
+**1. pymaster can't compile its C library** (commit `a1e2a41`). pymaster 2.6 builds
+`libnmt` from sdist via autotools; the new base image dropped the `libtool` package, so
+`autoreconf` failed with `Makefile.am:3: error: Libtool library used but 'LIBTOOL' is
+undefined` → `pip install -e .` aborted. Fix: add `autoconf automake libtool pkg-config`
+to the apt step. (The base still ships GSL/FFTW/CFITSIO dev libs, so libtool was the only
+missing piece — but pymaster compiling from source at all means those could vanish next.)
+
+**2. `import sp_validation` fails at runtime even though install succeeded** (commit
+`d4a64e4`). The new base image runs out of a **uv venv**: `VIRTUAL_ENV=/app/.venv`,
+`include-system-site-packages = false`, **shapepipe itself lives in the venv**
+(`/app/src/shapepipe`), and the venv has **no `pip`**. So bare `pip install -e .` fell
+through to `/usr/local/bin/pip` and installed into the *system* python
+(`/usr/local/lib/python3.12`), invisible to the `python` that `docker run` actually uses
+(the venv). The CI smoke test `docker run <img> python -c "import sp_validation"` then
+threw `ModuleNotFoundError`. Fix: install with **`uv pip install`** (uv ships at
+`/usr/local/bin/uv`, honors `VIRTUAL_ENV`) so packages land in `/app/.venv` alongside
+shapepipe. Verified the image green after both fixes.
+
+**Diagnosis tool:** `apptainer exec --cleanenv docker://ghcr.io/cosmostat/shapepipe:develop
+bash -lc '...'` lets you inspect the base image's real env (PATH, `pyvenv.cfg`, where
+shapepipe imports from) without a full Docker build — far faster than CI round-trips. Pin
+host PATH (`export PATH=/usr/local/bin:/usr/bin:/bin`) so host tools don't leak in.
+
+**Standing risk:** because the base is a moving tag, a future upstream rebuild can break the
+build again with no change on our side. If this recurs, first `diff` the base image's env
+against what the Dockerfile assumes (uv venv, autotools, dev libs) before touching our code.
+
+## CI now runs the unit suite inside this image
+
+As of PR #186 (2026-06-03), `deploy-image.yml` runs `pytest -m "not slow"` inside the built
+image, right after the `import sp_validation` smoke test. This is deliberate: the heavy
+system-dependency stack (pymaster's GSL/FFTW/CFITSIO, etc.) already lives in the image, so
+running tests there is reliable — re-solving those deps on a bare GitHub runner would be the
+same fight that broke the build above. The Dockerfile installs the `[test]` extra (`uv pip
+install -e '.[test]'`) so pytest is present. The dead `ci-build.yml` (master-triggered,
+py3.8, conda, `setup.py test` — never fired) was deleted; `cd-build.yml` is the same era and
+still dead (docs→gh-pages), left for a separate cleanup. Tests must stay hermetic for the
+`not slow` set: catalog-data-dependent tests are marked `@pytest.mark.slow` so they only run
+on the cluster (the image has `cat_config.yaml` but no catalogs).

--- a/.felt/docs-deploy-modernized/docs-deploy-modernized.md
+++ b/.felt/docs-deploy-modernized/docs-deploy-modernized.md
@@ -1,0 +1,20 @@
+---
+name: 'Docs deploy modernized: gh-pages CI + Sphinx 8'
+tags:
+    - docs
+    - ci
+created-at: 2026-06-04T00:47:23.328929872+02:00
+outcome: Replaced the dead master/py3.8/conda cd-build.yml with a deploy-docs job in deploy-image.yml that builds inside the freshly-published container image and pushes API docs to gh-pages on develop. Modernized the docs stack and conf.py for Sphinx 8+/9.
+---
+
+The old `cd-build.yml` was a relic of the pre-uv era: triggered on `master`, set up py3.8 via conda, ran `setup.py test`, and deployed Sphinx API docs to gh-pages. Fully dead since the move to `develop`/uv and the container CI. Removed it; the image build + tests now live in `deploy-image.yml` (see [[docker-build-uv-venv-base]]).
+
+**New CI shape.** Docs are a `deploy-docs` job in `deploy-image.yml`, `needs: build-and-push-image`, gated `if: github.ref == 'refs/heads/develop'`. It runs *inside* the just-published `ghcr.io/cosmostat/sp_validation:develop` image (which already carries the full scientific stack autodoc needs to import), `uv pip install '.[docs]'`, then `sphinx-apidoc … src/sp_validation` + `sphinx-build`, and deploys with `peaceiris/actions-gh-pages@v4`. Building in the image is the key move — it avoids recompiling pymaster/pyccl on a bare runner.
+
+**Stack haussmannized.** The `docs` extra dropped exact py3.8-era pins (sphinx 4.3.1, myst 0.16, nbsphinx, jupyter) for `>=` floors: `sphinx>=8`, `myst-parser>=4`, `numpydoc>=1.8`, `sphinxcontrib-bibtex>=2.6`, `sphinxawesome-theme>=5.3`. nbsphinx/nbsphinx-link/jupyter removed entirely — there are no `.ipynb` in the docs, the notebook-autodiscovery code in conf.py was long commented out.
+
+**conf.py PEP 621 metadata trap.** Two `conf.py` lookups broke under modern packaging because `[project]` metadata no longer populates the legacy fields: `mdata['Home-page']` (removed; was only used by dead nbsphinx badge code) and `mdata['Author']` (PEP 621 `authors=[{name=…}]` lands in `Author-email` as `"Name <email>, …"`, not `Author`). Fixed author to `mdata.get('Author') or re.sub(r'\s*<[^>]*>','', mdata.get('Author-email','CosmoStat'))` → "Martin Kilbinger, Cail Daley, Sacha Guerrini". Also migrated removed-config: `autodoc_default_flags`→`autodoc_default_options`, `html_use_smartypants`→`smartquotes`, and the sphinxawesome 3.x theme options (`nav_include_hidden`/`show_nav`/`breadcrumbs_*`) → 5.x/6.x (`show_prev_next`/`show_scrolltop`/`globaltoc_includehidden`), dropping the bare `'sphinxawesome_theme'` extension entry (5.x loads via `html_theme` only).
+
+**Verified** by an ephemeral-uv smoke build (sphinx 9.1.0, myst 5.1.0, theme 6.0.2): full pipeline builds clean except `sphinx-apidoc`+autodoc of the real modules, which needs the container env the CI job provides. The remaining warnings are pre-existing content issues (markdown header levels, two stray `.md` not in any toctree).
+
+**One-time repo setting:** GitHub Pages must be enabled pointing at the `gh-pages` branch; the first develop run creates that branch.

--- a/.felt/sp-validation-restructuring.md
+++ b/.felt/sp-validation-restructuring.md
@@ -1,0 +1,132 @@
+---
+name: SP Validation Restructuring
+status: open
+created-at: 0001-01-01T00:00:00Z
+outcome: |-
+    Reorg plan, settled. Core move: promote the things you run (cosmo_val, cosmo_inference)
+    to top-level siblings over shared src/; curate notebooks/ to official demos; add a
+    TRACKED scratch/ with nbstripout + size hook. Division of labor (settled with Sacha):
+    WORKFLOW holds ALL analysis — generic, modular (Snakemake `module`), multi-person, makes
+    diagnostic plots too → single results/. PAPER dir holds only final-figure assembly (PDF,
+    color, layout, recombining for presentation) and may never touch Snakemake. SCRATCH is
+    per-person ad hoc, can hold custom workflows. The line: everything up to the inputs of a
+    paper figure is analysis. Shipped as a GitHub MILESTONE: (1) Sacha foundation merge, (2)
+    the restructuring proposal (PR #188 — proposal lives in the PR description + the fiber,
+    NOT committed to the repo; auto-closed by GitHub once its branch went empty),
+    (3) glass mocks → tomography, (4) input pipeline → tomography.
+---
+
+We're cleaning up `sp_validation` before the next analysis cycle. This fiber holds the
+settled reorg plan, refined across three Cail passes and a Cail+Sacha pass (2026-06-02),
+grounded in a full map of what's on disk. It ships as a GitHub milestone; this work is the
+restructuring proposal PR within it.
+
+## Guiding principle
+
+Make the things a person actually *runs* siblings at the top level, with shared library
+code underneath. The asymmetry that keeps causing confusion: `cosmo_val` is buried in
+`notebooks/` while `cosmo_inference/` is top-level. Fix that. Be aggressive on deletion —
+it all stays in git history.
+
+## Target top-level layout
+
+```
+sp_validation/
+├── src/sp_validation/    library — + glass_mock core folded in
+├── cosmo_val/            PROMOTED from notebooks/cosmo_val/ — validation code + config
+├── cosmo_inference/      ~as-is — inference code + config (cosmosis/cosmocov, pipeline.sh)
+├── workflow/             ALL analysis — modular Snakemake, multi-person → results/
+├── papers/               final-figure assembly only (PDF, color, layout)
+│   ├── catalog/             ← notebooks/cosmo_val/catalog_paper_plot/
+│   ├── cosmic_shear_2d/     ← 2D_cosmic_shear_paper_plots/   (config space)
+│   ├── harmonic/            ← 2D_harmonic_space_..._plots/   (harmonic space)
+│   └── bmodes/              ← 2D_bmodes_paper_workflow/      (analysis → workflow/)
+├── scripts/             only REAL reduction scripts (catalog builders, masking)
+├── scratch/             TRACKED, per-person — ad hoc + personal custom workflows
+├── notebooks/           CURATED — official demo / tutorial notebooks only
+├── results/             analysis products + diagnostic plots; CONTENTS gitignored
+├── docs/  tests/  config/
+```
+
+`cosmo_val` and `cosmo_inference` sit side by side as the code+config homes (someone who
+only does validation opens `cosmo_val/`); `workflow/` orchestrates the analysis across
+them.
+
+## Division of labor (settled with Sacha)
+
+The boundary is **the inputs to a paper figure**: everything up to that point is analysis;
+the figure itself is presentation.
+
+- **`workflow/` — all analysis.** Generic, reusable, modular, organized for multiple people.
+  Produces analysis products *and diagnostic plots* (sp_validation makes many — fine, they
+  go to `results/`). This is where the bulk of the work lives.
+- **`papers/<paper>/` — final-figure assembly only.** Building the figure PDF, tweaking
+  colors/layout, recombining data for presentation. Tied to one paper; **may never touch
+  Snakemake.** Not everyone uses it.
+- **`scratch/<person>/` — personal & ad hoc.** Experimentation, and personal *custom
+  workflows* for one-off analysis. Tracked (sharing scratch is valuable).
+
+## Why the workflow is modular, not monolithic
+
+Nothing in real science is computed once — the catalog changed ~20× in the first release
+suite, and every paper varies the data vector, covariance, and inference. So the workflow
+is **parameterized, not a fixed run**: the shared thing is the rules, the config changes
+every time. Snakemake's `module` directive imports rule *definitions* under your own config
+and an output `prefix`, and lets you override individual rules:
+
+```python
+module analysis:
+    snakefile: "../../workflow/Snakefile"
+    config:    config              # this run's catalog, cuts, blind
+    prefix:    "results/bmodes"    # products land here — no clobbering
+use rule * from analysis
+# swap is per-rule: redefine just the data-vector rule with the same output to override
+```
+
+Single top-level `results/`; each run/paper namespaces under `results/<name>/` via the
+`prefix`. **DAG dry-run** (`snakemake --dry-run`) is the backpressure starter — the safety
+net for the module work; the broader test suite fills in during implementation.
+
+## Cleanup
+
+- **`defunct/`** — already quarantined (Oct 2024). Delete.
+- **`notebooks/`** — curated to *official* demo/tutorial notebooks only; the rest deleted or
+  moved to scratch. Salvage `run_cosmo_val.py` + `cat_config.yaml` → `cosmo_val/`;
+  `catalog_paper_plot/` → `papers/catalog/`; Martin's real reduction notebooks → `scripts/`.
+- **`scratch/`** is tracked, not gitignored. Bloat guard is tooling: `nbstripout` (strips
+  notebook outputs on commit — git is 319 MB today, heavy from *committed notebook outputs*,
+  and the `.gitignore` is scarred with hand-listed notebook paths) + a pre-commit size hook.
+- **Path translation** — collecting paper dirs breaks ~35 hardcoded absolute paths (mostly
+  `cosmosis_fitting.py`, `eb_plots.py`, `contour_plots.py`, glass-mock scripts; several at
+  `/home/guerrini/…`). Mechanical sweep, covering `scripts/` too → single repo-relative
+  `results/`.
+- **gitignore fix** — root `results/` and `output/` aren't currently ignored; ignore
+  `results/` contents (keep the dir), drop the hand-listed notebook block.
+
+## The milestone
+
+Shipped as a GitHub milestone, a suite of PRs in sequence:
+
+1. **Foundation** — Sacha merges his pending local code into `develop`. His to make.
+2. **Restructuring** — PR #188. The proposal is *not* committed to the repo: it lives in
+   the PR description and here in the fiber (`report.html`, `proposal.md`; rendered PDF
+   for PR attachment). Decided 2026-06-03 that a rendered report shouldn't sit in the code
+   tree. With nothing committed, the branch == `develop` and GitHub auto-closed the PR.
+3. **Glass mocks → tomography** — stub.
+4. **Input pipeline → tomography** — stub.
+
+## Implementation sequencing (within PR 2 when it goes live)
+
+1. Delete `defunct/` + audited old notebooks; fix `.gitignore`.
+2. Promote `cosmo_val/`, collect `papers/`, curate `notebooks/`, fold glass_mock into `src/`.
+3. Path-translation sweep (paper plots + scripts) → single `results/`.
+4. Add `scratch/`, nbstripout + size hook, README discipline; DAG-dry-run test.
+5. (incremental) build out modular `workflow/`; wire the first paper as a `module` composition.
+
+## Resolved decisions
+
+- harmonic vs cosmic_shear are **separate** papers (harmonic vs config space), separate dirs.
+- outputs go to a **single top-level `results/`**, namespaced per run via module `prefix`.
+- Martin's reduction notebooks: which are real scripts — review with Martin.
+- `2D_bmodes_paper_workflow/` is not split mid-paper: its analysis folds into `workflow/`,
+  its final figures into `papers/bmodes/`, sequenced after Sacha's foundation merge.

--- a/.felt/sp-validation-restructuring/proposal.md
+++ b/.felt/sp-validation-restructuring/proposal.md
@@ -1,0 +1,100 @@
+# Restructuring `sp_validation`
+
+*A proposal — draft, no implementation yet. The rich version of this document is
+[`proposal.html`](./proposal.html).*
+
+One organizing principle — **the things you run live at the top** — a clean three-way
+split between analysis, papers, and scratch, and a modular workflow built for more than one
+person.
+
+---
+
+## The shape
+
+Today `cosmo_val` is buried inside `notebooks/` while `cosmo_inference/` is top-level, so
+you constantly hunt for where each one lives. The fix: the things a person actually runs
+sit side by side at the top, sharing library code in `src/` underneath.
+
+```
+sp_validation/
+├── src/sp_validation/   library code (+ glass_mock core)
+├── cosmo_val/           validation: code + config        (promoted from notebooks/)
+├── cosmo_inference/     inference: code + config         (cosmosis / cosmocov)
+├── workflow/            ALL analysis — modular Snakemake, multi-person → results/
+├── papers/             final-figure assembly only (PDF, colour, layout)
+├── scripts/            real reduction scripts (catalog builders, masking)
+├── scratch/            per-person — ad hoc work + personal workflows (tracked)
+├── notebooks/          curated to official demos / tutorials
+├── results/            analysis products + diagnostic plots (contents gitignored)
+└── docs/  tests/  config/
+```
+
+---
+
+## Division of labor
+
+The boundary is **the inputs to a paper figure**: everything up to that point is analysis;
+the figure itself is presentation.
+
+- **`workflow/` — all analysis.** Generic, reusable, modular, organized for multiple people.
+  Produces analysis products *and diagnostic plots* (sp_validation makes many — they go to
+  `results/`). The bulk of the work lives here.
+- **`papers/<paper>/` — final-figure assembly only.** The figure PDF, colours, layout,
+  recombining data for presentation. Tied to one paper, and may never touch Snakemake.
+- **`scratch/<person>/` — personal and ad hoc.** Experiments and one-off custom workflows.
+  Tracked, because seeing each other's scratch is useful.
+
+---
+
+## How the workflow scales — modular, not monolithic
+
+Nothing in this analysis is computed once: the catalog changed ~20× in the first release
+suite, and every paper varies the data vector, covariance, and inference. So the workflow
+is *parameterized* — the rules are shared, the config changes each time. Snakemake's
+`module` directive imports the rules under your own config and an output `prefix`, and lets
+you override any single rule:
+
+```python
+module analysis:
+    snakefile: "../../workflow/Snakefile"
+    config:    config              # this run's catalog, cuts, blind
+    prefix:    "results/bmodes"    # products land here — no clobbering
+
+use rule * from analysis
+# swap is per-rule: redefine just the data-vector rule to override it
+```
+
+One top-level `results/`; each run namespaces under `results/<name>/` via the prefix, so
+people don't clobber each other. A `--dry-run` on each composition is the safety net that
+lets the structure grow without silent breakage.
+
+---
+
+## Cleanup
+
+- **Delete** `defunct/` (quarantined since 2024) and the exploratory 2021–22 notebooks — it
+  all stays in git history.
+- **Curate** `notebooks/` to official demos and tutorials; personal scratchy ones move to
+  `scratch/`.
+- **Discipline** via tooling, not bans: `nbstripout` strips notebook outputs on commit (the
+  repo's weight today is committed notebook outputs), plus a pre-commit size hook.
+- **Path translation** — collecting the paper dirs breaks ~35 hardcoded absolute paths; a
+  mechanical sweep rewrites them (scripts included) to the single repo-relative `results/`.
+
+---
+
+## The milestone
+
+A suite of PRs, in sequence:
+
+1. **Foundation** — merge pending local code into `develop`. *(Sacha)*
+2. **Restructuring** — this proposal. *(this PR — draft, no implementation yet)*
+3. **Glass mocks → tomography.**
+4. **Input pipeline → tomography.**
+
+This PR is the proposal only. Implementation follows once the foundation merge lands and
+the shape is agreed.
+
+---
+
+*— Claude on behalf of Cail*

--- a/.felt/sp-validation-restructuring/report.html
+++ b/.felt/sp-validation-restructuring/report.html
@@ -1,0 +1,180 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>sp_validation — restructuring proposal</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --parchment: #EDE2CE;
+    --rag: #FBF6E9;
+    --ink: #1B1611;
+    --ink-muted: #7A6F5C;
+    --cinnabar: #BC4538;
+    --teal: #3F8278;
+    --cobalt: #3D5BA0;
+    --ochre: #C49333;
+    --rule: #C5B89E;
+    --serif: 'EB Garamond', Georgia, serif;
+    --mono: 'IBM Plex Mono', 'JetBrains Mono', ui-monospace, monospace;
+  }
+  html, body { margin: 0; padding: 0; }
+  body { background: var(--parchment); color: var(--ink); font-family: var(--serif); font-size: 19px; line-height: 1.55; -webkit-font-smoothing: antialiased; }
+  .page { max-width: 880px; margin: 0 auto; padding: 56px 32px 72px; }
+  .stamp { font-family: var(--mono); font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--ink-muted); margin-bottom: 20px; display: flex; gap: 14px; align-items: center; flex-wrap: wrap; }
+  .stamp .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--cinnabar); }
+  .stamp .sep { color: var(--rule); }
+  h1 { font-family: var(--serif); font-style: italic; font-weight: 500; font-size: 44px; line-height: 1.08; margin: 0 0 14px; }
+  .lede { font-size: 21px; color: var(--ink); margin: 0; }
+  .lede em { color: var(--cinnabar); font-style: italic; }
+  section { margin-top: 46px; }
+  .section-mark { font-family: var(--mono); font-size: 11px; letter-spacing: 0.15em; text-transform: uppercase; color: var(--cinnabar); margin-bottom: 8px; }
+  h2 { font-family: var(--serif); font-style: italic; font-weight: 500; font-size: 29px; line-height: 1.2; margin: 0 0 18px; }
+  p { margin: 0 0 15px; }
+  ul { margin: 0 0 15px; padding-left: 22px; }
+  li { margin-bottom: 9px; }
+  code { font-family: var(--mono); font-size: 0.86em; background: rgba(196, 147, 51, 0.15); padding: 1px 5px; border-radius: 2px; }
+  hr { border: none; border-top: 1px solid var(--rule); margin: 38px 0; }
+  hr.short { width: 80px; margin: 30px 0; border-top: 2px solid var(--cinnabar); }
+
+  pre.tree { font-family: var(--mono); font-size: 13px; line-height: 1.72; background: var(--rag); border: 1px solid var(--rule); border-radius: 4px; padding: 20px 22px; overflow-x: auto; white-space: pre; }
+  pre.tree .new  { color: var(--teal); font-weight: 500; }
+  pre.tree .keep { color: var(--ink); }
+  pre.tree .ann  { color: var(--ink-muted); }
+  .legend { font-family: var(--mono); font-size: 12px; display: flex; gap: 22px; flex-wrap: wrap; margin-top: 10px; color: var(--ink-muted); }
+  .legend .sw { display: inline-block; width: 10px; height: 10px; border-radius: 2px; margin-right: 6px; vertical-align: middle; }
+  .legend .sw.t { background: var(--teal); } .legend .sw.k { background: var(--ink); } .legend .sw.c { background: var(--cinnabar); }
+
+  pre.code { font-family: var(--mono); font-size: 12.5px; line-height: 1.6; background: #211B14; color: #E6DCC8; border-radius: 4px; padding: 17px 20px; overflow-x: auto; white-space: pre; }
+  pre.code .c { color: #9B8A6B; } pre.code .k { color: #E0A04D; } pre.code .s { color: #8FB9A8; }
+
+  .lanes { display: flex; gap: 16px; flex-wrap: wrap; margin: 22px 0 8px; }
+  .lane { flex: 1 1 220px; background: var(--rag); border: 1px solid var(--rule); border-top-width: 3px; border-radius: 4px; padding: 16px 18px; }
+  .lane.wf { border-top-color: var(--teal); } .lane.pp { border-top-color: var(--cobalt); } .lane.sc { border-top-color: var(--ochre); }
+  .lane .tag { font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; margin-bottom: 8px; }
+  .lane.wf .tag { color: var(--teal); } .lane.pp .tag { color: var(--cobalt); } .lane.sc .tag { color: var(--ochre); }
+  .lane p { font-size: 16px; line-height: 1.45; margin: 0; }
+  .boundary { font-style: italic; color: var(--ink); border-left: 2px solid var(--ochre); padding-left: 18px; margin: 16px 0 0; }
+  .boundary strong { font-style: normal; }
+
+  ol.seq { counter-reset: step; list-style: none; padding-left: 0; margin: 8px 0 0; }
+  ol.seq > li { counter-increment: step; position: relative; padding-left: 46px; margin-bottom: 16px; }
+  ol.seq > li::before { content: counter(step); position: absolute; left: 0; top: -1px; width: 28px; height: 28px; border-radius: 50%; background: var(--ink-muted); color: var(--rag); font-family: var(--mono); font-size: 14px; display: flex; align-items: center; justify-content: center; }
+  ol.seq > li.here::before { background: var(--cinnabar); }
+  ol.seq .who { font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--ink-muted); margin-left: 8px; }
+  ol.seq .here-tag { font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--cinnabar); margin-left: 8px; }
+</style>
+</head>
+<body>
+<main class="page">
+
+  <div class="stamp">
+    <span class="dot"></span><span>2026 · 06 · 02</span>
+    <span class="sep">·</span><span>sp_validation</span>
+    <span class="sep">·</span><span>restructuring proposal</span>
+  </div>
+
+  <h1>Restructuring sp_validation.</h1>
+  <p class="lede">One organizing principle — <em>the things you run live at the top</em> — a clean three-way split between analysis, papers, and scratch, and a modular workflow built for more than one person.</p>
+
+  <hr>
+
+  <section>
+    <div class="section-mark">§ The shape</div>
+    <h2>Runnable things become top-level siblings.</h2>
+    <p>Today <code>cosmo_val</code> is buried inside <code>notebooks/</code> while <code>cosmo_inference/</code> is top-level — so you constantly hunt for where each one lives. The fix: the things a person actually runs sit side by side at the top, sharing library code in <code>src/</code> underneath.</p>
+
+<pre class="tree"><span class="keep">sp_validation/</span>
+├── <span class="keep">src/sp_validation/</span>   <span class="ann">library code (+ glass_mock core)</span>
+├── <span class="keep">cosmo_val/</span>           <span class="ann">validation: code + config        (promoted from notebooks/)</span>
+├── <span class="keep">cosmo_inference/</span>     <span class="ann">inference: code + config         (cosmosis / cosmocov)</span>
+├── <span class="new">workflow/</span>            <span class="ann">ALL analysis — modular Snakemake, multi-person → results/</span>
+├── <span class="new">papers/</span>              <span class="ann">final-figure assembly only (PDF, colour, layout)</span>
+├── <span class="keep">scripts/</span>            <span class="ann">real reduction scripts (catalog builders, masking)</span>
+├── <span class="new">scratch/</span>            <span class="ann">per-person — ad hoc work + personal workflows (tracked)</span>
+├── <span class="keep">notebooks/</span>          <span class="ann">curated to official demos / tutorials</span>
+├── <span class="new">results/</span>            <span class="ann">analysis products + diagnostic plots (contents gitignored)</span>
+└── <span class="keep">docs/  tests/  config/</span></pre>
+
+    <div class="legend">
+      <span><span class="sw t"></span>new / restructured</span>
+      <span><span class="sw k"></span>kept (some curated)</span>
+      <span><span class="sw c"></span>deleted: defunct/, scratchy notebooks</span>
+    </div>
+  </section>
+
+  <hr class="short">
+
+  <section>
+    <div class="section-mark">§ Division of labor</div>
+    <h2>Analysis, papers, scratch.</h2>
+
+    <div class="lanes">
+      <div class="lane wf">
+        <div class="tag">workflow/</div>
+        <p>All analysis. Generic, reusable, modular, organized for multiple people. Makes diagnostic plots too — they go to <code>results/</code>. The bulk of the work lives here.</p>
+      </div>
+      <div class="lane pp">
+        <div class="tag">papers/</div>
+        <p>Final-figure assembly only — the figure PDF, colours, layout, recombining data for presentation. Tied to one paper, and may never touch Snakemake.</p>
+      </div>
+      <div class="lane sc">
+        <div class="tag">scratch/</div>
+        <p>Personal and ad hoc. Experiments and one-off custom workflows. Tracked, because seeing each other's scratch is useful.</p>
+      </div>
+    </div>
+
+    <p class="boundary"><strong>The line:</strong> everything up to the inputs of a paper figure is analysis, and belongs in the workflow. The figure itself is presentation, and belongs to the paper.</p>
+  </section>
+
+  <hr class="short">
+
+  <section>
+    <div class="section-mark">§ How the workflow scales</div>
+    <h2>Modular, not monolithic.</h2>
+    <p>Nothing in this analysis is computed once — the catalog changed ~20× in the first release suite, and every paper varies the data vector, covariance, and inference. So the workflow is <em>parameterized</em>: the rules are shared, the config changes each time. Snakemake's <code>module</code> directive imports the rules under your own config and an output <code>prefix</code>, and lets you override any single rule:</p>
+
+<pre class="code"><span class="k">module</span> analysis:
+    snakefile: <span class="s">"../../workflow/Snakefile"</span>
+    config:    config              <span class="c"># this run's catalog, cuts, blind</span>
+    prefix:    <span class="s">"results/bmodes"</span>    <span class="c"># products land here — no clobbering</span>
+
+<span class="k">use rule</span> * <span class="k">from</span> analysis
+<span class="c"># swap is per-rule: redefine just the data-vector rule to override it</span></pre>
+
+    <p>One top-level <code>results/</code>; each run namespaces under <code>results/&lt;name&gt;/</code> via the prefix, so people don't clobber each other. A <code>--dry-run</code> on each composition is the safety net that lets the structure grow without silent breakage.</p>
+  </section>
+
+  <hr class="short">
+
+  <section>
+    <div class="section-mark">§ Cleanup</div>
+    <h2>Delete, curate, discipline.</h2>
+    <ul>
+      <li><strong>Delete</strong> <code>defunct/</code> (quarantined since 2024) and the exploratory 2021–22 notebooks. It all stays in git history.</li>
+      <li><strong>Curate</strong> <code>notebooks/</code> to official demos and tutorials; personal scratchy ones move to <code>scratch/</code>.</li>
+      <li><strong>Discipline</strong> via tooling, not bans: <code>nbstripout</code> strips notebook outputs on commit (the repo's weight today is committed notebook outputs), plus a pre-commit size hook.</li>
+      <li><strong>Path translation</strong> — collecting the paper dirs breaks ~35 hardcoded absolute paths; a mechanical sweep rewrites them (scripts included) to the single repo-relative <code>results/</code>.</li>
+    </ul>
+  </section>
+
+  <hr class="short">
+
+  <section>
+    <div class="section-mark">§ The milestone</div>
+    <h2>A suite of PRs, in sequence.</h2>
+    <ol class="seq">
+      <li>Foundation — merge pending local code into <code>develop</code>. <span class="who">Sacha</span></li>
+      <li class="here">Restructuring — this proposal. <span class="here-tag">this PR · draft, no implementation yet</span></li>
+      <li>Glass mocks → tomography.</li>
+      <li>Input pipeline → tomography.</li>
+    </ol>
+    <p style="color:var(--ink-muted); margin-top:18px;">This PR is the proposal only. Implementation follows once the foundation merge lands and the shape is agreed.</p>
+  </section>
+
+</main>
+</body>
+</html>

--- a/.gitignore
+++ b/.gitignore
@@ -186,5 +186,8 @@ cosmo_inference/cosmosis_config/cosmosis_pipeline_glass_mocks_v0*.ini
 cosmo_inference/cosmosis_config/cosmosis_pipeline_glass_mock_0*.ini
 cosmo_inference/cosmosis_config/cosmosis_pipeline_glass_mock_v0*.ini
 
-CLAUDE.md
-AGENTS.md
+# felt — track the fiber records (engineering decisions & findings); skip only
+# the regenerable index and runtime locks.
+.felt/*.db
+.felt/*.lock
+.felt/index-sync.*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,82 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+SP Validation is a Python package for validating weak-lensing catalogues (galaxy and star shapes) produced by ShapePipe. The package performs:
+
+1. **Shear validation**: Calibrates shear catalogues with metacal information, performs PSF leakage tests
+2. **Post processing**: Further processing of calibrated shear catalogues  
+3. **Cosmology validation**: Diagnostics like rho/tau statistics, E-/B-mode decomposition
+4. **Cosmology inference**: Two-point correlation function analysis using CosmoSIS/CosmoCov
+
+## Development Commands
+
+### Testing
+- Run all tests: `pytest`
+- Run fast tests only (recommended for development): `pytest -m "not slow"`
+- Run tests with coverage: `pytest --cov=sp_validation --cov-report=term --cov-report=xml`
+- Run single test: `pytest src/sp_validation/tests/test_cosmology.py::test_function_name`
+- Test performance: Fast tests ~13s, all tests ~18s (vs 30s originally)
+- Test tolerances: Optimized based on actual agreement levels and physics constraints
+
+### Linting and Code Quality
+- Check code style: `ruff check`
+- Auto-fix issues: `ruff check --fix`
+- Line length limit: 88 characters
+
+### Installation 
+- Install in development mode: `pip install -e .[develop]`
+- Install test dependencies: `pip install -e .[test]`
+
+## Architecture
+
+### Core Package Structure (`src/sp_validation/`)
+- `basic.py`: Basic utilities and mathematical functions
+- `calibration.py`: Shear calibration routines
+- `cat.py`: Catalogue handling and manipulation
+- `cosmo_val.py`: Cosmology validation routines
+- `cosmology.py`: Cosmological calculations and theory
+- `galaxy.py`: Galaxy-specific processing
+- `io.py`: Input/output utilities
+- `plots.py`: Plotting functions
+- `rho_tau.py`: Rho and tau statistics calculations
+- `survey.py`: Survey-level operations
+- `util.py`: General utilities
+
+### External Tools Integration
+- **CosmoSIS**: Cosmological inference pipeline (requires separate installation)
+- **CosmoCov**: Covariance matrix calculations (requires separate installation)
+- **TreeCorr**: Two-point correlation functions
+- **Healpy/HealSparse**: Sky map handling
+
+### Cosmology Inference Pipeline (`cosmo_inference/`)
+Run via `./pipeline.sh` with flags:
+- `--pcf`: Calculate 2-point correlation functions
+- `--covmat`: Calculate covariance matrix with CosmoCov
+- `--inference`: Run CosmoSIS inference
+- `--mcmc_process`: Analyze MCMC chains
+
+### Configuration
+Main configuration in `notebooks/params.py` with parameters:
+- `name`: Field/patch identifier
+- `data_dir`: Input data directory
+- `galaxy_cat_path`: Galaxy catalogue path (.fits/.hdf5)
+- `star_cat_path`: Star catalogue path (.fits)
+
+### Key Dependencies
+- astropy, numpy, scipy for core calculations
+- treecorr for correlation functions
+- healpy/healsparse for sky maps
+- emcee for MCMC sampling
+- pyccl for cosmological calculations
+
+## Container Usage
+Recommended installation via Apptainer/Docker:
+```bash
+apptainer build --sandbox sp_validation docker://ghcr.io/cosmostat/sp_validation:develop
+```
+
+## Notebook Configuration
+- The CosmologyValidation class must be initialized in notebooks/cosmo_val


### PR DESCRIPTION
Start carrying the project's accumulated engineering context in the repo itself, rather than only in a local store. The value is the compounding context — a flywheel that future work and future agents pick up from.

Two parts:

- **Stop gitignoring `CLAUDE.md`** (and its `AGENTS.md` symlink). They're professional codebase documentation and belong with the code.

- **Track the `.felt/` fibers**: engineering decision and finding records — catalog/version notes, the Docker/CI uv-venv breakage and fix, the docs-deploy modernization, the restructuring plan. The regenerable FTS index (`*.db`) and runtime locks stay gitignored; only the records themselves are tracked.

These are deliberately impartial, reusable engineering records (the personal dispatch config was stripped from the restructuring fiber). Maintained on develop.

— Claude on behalf of Cail

🤖 Generated with [Claude Code](https://claude.com/claude-code)