### PR TITLE
fix: dimensionally wrong T_to_fwhm distorted the PSF-leakage size axis

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "camb",
     "clmm",
     "colorama",
-    "cs_util>=0.1.9",
+    "cs_util>=0.2.1",
     "emcee",
     "getdist @ git+https://github.com/benabed/getdist.git@upper_triangle_whisker",
     "h5py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,8 @@ docs = [
     "myst-parser>=4.0",
     "numpydoc>=1.8",
     "sphinxcontrib-bibtex>=2.6",
-    "sphinxawesome-theme>=5.3"
+    # 6.0.3 is a broken wheel on PyPI (dist-info only, no python module)
+    "sphinxawesome-theme>=5.3,!=6.0.3"
 ]
 develop = ["sp_validation[test,docs]"]
 

--- a/src/sp_validation/galaxy.py
+++ b/src/sp_validation/galaxy.py
@@ -24,50 +24,12 @@ from astropy.wcs import WCS
 from astropy.nddata import bitmask
 
 from cs_util import cfis
+from cs_util.size import T_to_fwhm, sigma_to_fwhm  # noqa: F401  re-exported;
+# the previous local T_to_fwhm (T / 1.17741 * 2.355) treated the area
+# T = 2 sigma^2 as if it were sigma; the cs_util version carries the
+# required square root: FWHM = 2.35482 sqrt(T / 2)
 
 from sp_validation import io
-
-
-def T_to_fwhm(T):
-    """T to fwhm.
-
-    Transform from size T to FWHM.
-    This interprets T as the RMS (``sigma``) of a Gaussian.
-
-    Parameters
-    ----------
-    T : (array of) float
-        input size(s)
-
-    Returns
-    -------
-    fwhm : (array of) float
-        output fwhm(s)
-    """
-
-    # MKDEBUG: Check this equation. Why is FWHM not quadratic in T???
-    return T / 1.17741 * 2.355
-
-
-def sigma_to_fwhm(sigma, pixel_size=1):
-    """Sigma to fwhm.
-
-    Transform from size sigma to FWHM.
-
-    Parameters
-    ----------
-    sigma : (array of) float
-        input size(s)
-    pixel_size : float, optional, default=1
-        pixel size in arcsec, set to 1 if no scaling
-        required
-
-    Returns
-    -------
-    fwhm : (array of) float
-        output fwhm(s)
-    """
-    return sigma * 2.355 * pixel_size
 
 
 def classification_galaxy_overlap_ra_dec(

--- a/src/sp_validation/tests/test_galaxy.py
+++ b/src/sp_validation/tests/test_galaxy.py
@@ -1,0 +1,40 @@
+"""UNIT TESTS FOR GALAXY SUBPACKAGE.
+
+This module contains unit tests for the module package
+sp_validation.galaxy.
+
+:Author: Cail Daley <cailmdaley@gmail.com>
+
+"""
+
+from unittest import TestCase
+
+import numpy.testing as npt
+
+
+class GalaxyTestCase(TestCase):
+
+    def test_galaxy_imports(self):
+        """Test that the galaxy module imports.
+
+        The package-level imports in ``sp_validation/__init__.py`` are
+        commented out, so without this smoke test a broken dependency
+        (e.g. a cs_util without ``cs_util.size``) passes CI silently.
+        """
+        from sp_validation import galaxy  # noqa: F401
+
+    def test_T_to_fwhm_is_dimensionally_correct(self):
+        """Test FWHM(T) = 2 sqrt(2 ln 2) sqrt(T / 2) = 2.35482 sigma.
+
+        T = 2 sigma^2 is an area; the conversion to the length FWHM
+        carries a square root. The previous local implementation
+        (T / 1.17741 * 2.355) was linear in T and only coincided with
+        the correct value near sigma = 0.5.
+        """
+        from sp_validation.galaxy import T_to_fwhm, sigma_to_fwhm
+
+        # unit-sigma Gaussian: T = 2, FWHM = 2.35482
+        npt.assert_allclose(T_to_fwhm(2.0), 2.3548200450, rtol=1e-6)
+        npt.assert_allclose(sigma_to_fwhm(1.0), 2.3548200450, rtol=1e-6)
+        # the old linear form would give 4.0 here
+        npt.assert_allclose(T_to_fwhm(2.0), sigma_to_fwhm(1.0))


### PR DESCRIPTION
## What

`galaxy.py`'s local `T_to_fwhm` was dimensionally wrong: `T / 1.17741 * 2.355` treats the *area* `T = 2σ²` as if it were `σ`. The correct conversion carries a square root: `FWHM = 2.35482 √(T/2)`. The two coincide only near σ = 0.5 (T = 0.5 → 1.0008 vs 1.0) and diverge sharply elsewhere (T = 2 → old 4.0 vs correct 2.355) — a monotonic but nonlinear distortion of the PSF-leakage size axis (per-bin α(size) trends). Results produced through the old function should be regenerated.

The local converters are deleted and re-exported from `cs_util.size` (CosmoStat/cs_util#65, released as **cs_util 0.2.1**) — the shared single source of truth for the T/σ/r50/FWHM web, also adopted on the ShapePipe side (CosmoStat/shapepipe#743). The pin moves to `cs_util>=0.2.1` so a fresh install resolves a size-bearing cs_util (PyPI 0.2 predates the module).

A new `tests/test_galaxy.py` closes the hole that let this hide: the package-level imports in `__init__.py` are commented out, so CI's `import sp_validation` smoke test never touched `galaxy` — a broken `cs_util.size` import would have passed CI. The test imports `galaxy` directly and pins `T_to_fwhm(2.0) = 2.35482`.

Note: `sigma_to_fwhm` loses its unused `pixel_size` kwarg (never passed anywhere in src/ or notebooks; it was only ever used single-argument via the `size_to_fwhm` dispatch table).

## Merge discipline — do not merge yet

`shear_psf_leakage@develop`'s poetry cap `cs-util = "^0.1.0"` (→ `<0.2.0`) conflicts with the `cs_util>=0.2.1` pin, so dependency resolution of this branch currently fails. **Merge after** CosmoStat/shear_psf_leakage relaxes the cap on `develop` (one line, `cs-util = ">=0.1.0,<0.3"`; its cs_util usage — `args`, `calc`, `cat`, `cosmo`, `logging`, `plots` — is signature-compatible with 0.2.x). With that cap relaxed, the full install + test suite passes from scratch: verified here with a fresh uv env (override simulating the relaxation) — cs_util 0.2.1 resolved from PyPI, `galaxy` imports, 35 passed / 6 deselected (`-m 'not slow'`).

— Claude on behalf of Cail
