### PR TITLE
refactor(cosmo_val): tighten the mixin modules (behavior-preserving cleanup)

### DIFF
--- a/src/sp_validation/cosmo_val/catalog_characterization.py
+++ b/src/sp_validation/cosmo_val/catalog_characterization.py
@@ -121,11 +121,9 @@ class CatalogCharacterizationMixin:
         }
 
         if overwrite_config:
-            if "cov_th" not in self.cc[ver]:
-                self.cc[ver]["cov_th"] = {}
-            self.cc[ver]["cov_th"]["A"] = float(area_deg2)
-            self.cc[ver]["cov_th"]["n_e"] = float(n_eff)
-            self.cc[ver]["cov_th"]["sigma_e"] = float(sigma_e)
+            self.cc[ver].setdefault("cov_th", {}).update(
+                A=float(area_deg2), n_e=float(n_eff), sigma_e=float(sigma_e)
+            )
             self._write_catalog_config()
 
         return results
@@ -268,7 +266,7 @@ class CatalogCharacterizationMixin:
         else:
             self.print_start("Computing ellipticity histograms:")
 
-            fig, axs = plt.subplots(1, 2, figsize=(22, 7))
+            _fig, axs = plt.subplots(1, 2, figsize=(22, 7))
             bins = np.linspace(-1.1, 1.1, nbins + 1)
             for ver in self.versions:
                 self.print_magenta(ver)
@@ -317,7 +315,7 @@ class CatalogCharacterizationMixin:
         else:
             self.print_start("Computing weight histograms:")
 
-            fig, ax = plt.subplots(1, 1, figsize=(10, 7))
+            plt.figure(figsize=(10, 7))
             for ver in self.versions:
                 self.print_magenta(ver)
                 with self.results[ver].temporarily_read_data():
@@ -345,7 +343,7 @@ class CatalogCharacterizationMixin:
     def plot_separation(self, nbins=200):
         self.print_start("Separation histograms")
         if "SP_matched_MP_v1.0" in self.versions:
-            fig, axs = plt.subplots(1, 1, figsize=(10, 7))
+            _fig, axs = plt.subplots(1, 1, figsize=(10, 7))
             with self.results["SP_matched_MP_v1.0"].temporarily_read_data():
                 sep = self.results["SP_matched_MP_v1.0"].dat_shear["Separation"]
             axs.hist(

--- a/src/sp_validation/cosmo_val/core.py
+++ b/src/sp_validation/cosmo_val/core.py
@@ -1,6 +1,7 @@
 # %%
 import copy
 import os
+import re
 from pathlib import Path
 
 import colorama
@@ -249,19 +250,17 @@ class CosmologyValidation(
             "cell_method must be 'map' or 'catalog'"
         )
         assert self.noise_bias_method in ["analytic", "randoms"], (
-            "noise_bias_method must be 'analytical' or 'randoms'"
+            "noise_bias_method must be 'analytic' or 'randoms'"
         )
         assert self.fiducial_input_inka in ["coupled", "decoupled"], (
             "fiducial_input_inka must be 'coupled' or 'decoupled'"
         )
 
-        # For theory calculations:
-        # Create cosmology object using new functionality
-        if cosmo_params is not None:
-            self.cosmo = get_cosmo(**cosmo_params)
-        else:
-            # Use Planck 2018 defaults
-            self.cosmo = get_cosmo()
+        # Cosmology for theory predictions: caller-supplied params, else the
+        # get_cosmo() Planck 2018 defaults.
+        self.cosmo = (
+            get_cosmo(**cosmo_params) if cosmo_params is not None else get_cosmo()
+        )
 
         self.treecorr_config = {
             "ra_units": "degrees",
@@ -276,15 +275,15 @@ class CosmologyValidation(
 
         self.catalog_config_path = Path(catalog_config)
         with self.catalog_config_path.open("r") as file:
-            self.cc = cc = yaml.load(file.read(), Loader=yaml.FullLoader)
+            self.cc = cc = yaml.load(file, Loader=yaml.FullLoader)
 
         def resolve_paths_for_version(ver):
             """Resolve relative paths for a version using its subdir."""
             subdir = Path(cc[ver]["subdir"])
-            for key in cc[ver]:
-                if "path" in cc[ver][key]:
-                    path = Path(cc[ver][key]["path"])
-                    cc[ver][key]["path"] = (
+            for section in cc[ver].values():
+                if "path" in section:
+                    path = Path(section["path"])
+                    section["path"] = (
                         str(path) if path.is_absolute() else str(subdir / path)
                     )
 
@@ -381,8 +380,6 @@ class CosmologyValidation(
         specified blind (A, B, or C) by replacing the blind suffix in the
         configured path.
         """
-        import re
-
         redshift_path = self.cc[version]["shear"]["redshift_path"]
 
         # Override blind if specified
@@ -398,9 +395,13 @@ class CosmologyValidation(
     def color_reset(self):
         print(colorama.Fore.BLACK, end="")
 
-    def print_blue(self, msg, end="\n"):
-        print(colorama.Fore.BLUE + msg, end=end)
+    def _print_color(self, color, msg, end="\n"):
+        """Print ``msg`` in ``color``, then restore the default foreground."""
+        print(color + msg, end=end)
         self.color_reset()
+
+    def print_blue(self, msg, end="\n"):
+        self._print_color(colorama.Fore.BLUE, msg, end=end)
 
     def print_start(self, msg, end="\n"):
         print()
@@ -410,30 +411,29 @@ class CosmologyValidation(
         self.print_blue(msg)
 
     def print_magenta(self, msg):
-        print(colorama.Fore.MAGENTA + msg)
-        self.color_reset()
+        self._print_color(colorama.Fore.MAGENTA, msg)
 
     def print_green(self, msg):
-        print(colorama.Fore.GREEN + msg)
-        self.color_reset()
+        self._print_color(colorama.Fore.GREEN, msg)
 
     def print_cyan(self, msg):
-        print(colorama.Fore.CYAN + msg)
-        self.color_reset()
+        self._print_color(colorama.Fore.CYAN, msg)
 
     def init_results(self, objectwise=False):
+        # Branch is loop-invariant: pick the leakage class and its parameter
+        # builder once, then apply per version.
+        make_leakage, set_params = (
+            (run_object.LeakageObject, self.set_params_leakage_object)
+            if objectwise
+            else (run_scale.LeakageScale, self.set_params_leakage_scale)
+        )
+
         results = {}
         for ver in self.versions:
-            # Set parameters depending on the type of leakage
-            if objectwise:
-                results[ver] = run_object.LeakageObject()
-                results[ver]._params.update(self.set_params_leakage_object(ver))
-            else:
-                results[ver] = run_scale.LeakageScale()
-                results[ver]._params.update(self.set_params_leakage_scale(ver))
-
-            results[ver].check_params()
-            results[ver].prepare_output()
+            leakage = results[ver] = make_leakage()
+            leakage._params.update(set_params(ver))
+            leakage.check_params()
+            leakage.prepare_output()
 
         return results
 
@@ -501,10 +501,11 @@ class CosmologyValidation(
                         )
                 except (KeyError, RuntimeError):
                     pass
-                if "eb_samples" in res:
-                    cov_methods.add("semi-analytic")
-                else:
-                    cov_methods.add(f"jackknife ({gg.npatch1} patches)")
+                cov_methods.add(
+                    "semi-analytic"
+                    if "eb_samples" in res
+                    else f"jackknife ({gg.npatch1} patches)"
+                )
 
             # COSEBIs PTE from stored results
             if ver in self._cosebis_results:

--- a/src/sp_validation/cosmo_val/cosebis.py
+++ b/src/sp_validation/cosmo_val/cosebis.py
@@ -138,7 +138,7 @@ class CosebisMixin:
                 gg=gg, nmodes=nmodes, scale_cuts=None, cov_path=cov_path
             )
             # Extract single results dict from scale_cuts dictionary
-            results = list(results.values())[0]
+            results = next(iter(results.values()))
 
         return results
 
@@ -237,19 +237,17 @@ class CosebisMixin:
 
         # Generate plots using specialized plotting functions
         # Extract single result for plotting if multiple scale cuts were evaluated
-        if isinstance(results, dict) and all(
-            isinstance(k, tuple) for k in results.keys()
-        ):
+        multiple_scale_cuts = isinstance(results, dict) and all(
+            isinstance(k, tuple) for k in results
+        )
+        if multiple_scale_cuts:
             # Multiple scale cuts: use fiducial_scale_cut if provided, otherwise use
-            # full range
-            if fiducial_scale_cut is not None:
-                plot_results = results[
-                    find_conservative_scale_cut_key(results, fiducial_scale_cut)
-                ]
-            else:
-                # Use full range result (largest scale cut)
-                max_range_key = max(results.keys(), key=lambda x: x[1] - x[0])
-                plot_results = results[max_range_key]
+            # full range (largest scale cut)
+            plot_results = results[
+                find_conservative_scale_cut_key(results, fiducial_scale_cut)
+                if fiducial_scale_cut is not None
+                else max(results, key=lambda x: x[1] - x[0])
+            ]
         else:
             # Single result
             plot_results = results
@@ -266,11 +264,7 @@ class CosebisMixin:
         )
 
         # Generate scale cut heatmap if we have multiple scale cuts
-        if (
-            isinstance(results, dict)
-            and all(isinstance(k, tuple) for k in results.keys())
-            and len(results) > 1
-        ):
+        if multiple_scale_cuts and len(results) > 1:
             # Create temporary gg object with correct binning for mapping
             treecorr_config_temp = {
                 **self.treecorr_config,

--- a/src/sp_validation/cosmo_val/pseudo_cl.py
+++ b/src/sp_validation/cosmo_val/pseudo_cl.py
@@ -145,7 +145,6 @@ class PseudoClMixin:
                 self.print_cyan(f"Extracting the fiducial power spectrum for {ver}")
 
                 lmax = 2 * self.nside
-                z, dndz = self.get_redshift(ver)
                 ell = np.arange(1, lmax + 1)
                 pw = hp.pixwin(nside, lmax=lmax)
                 if pw.shape[0] != len(ell) + 1:
@@ -158,7 +157,6 @@ class PseudoClMixin:
                 # Load redshift distribution and calculate theory C_ell
                 path_redshift_distr = self.cc[ver]["shear"]["redshift_path"]
                 z, dndz = np.loadtxt(path_redshift_distr, unpack=True)
-                ell = np.arange(1, lmax + 1)
                 fiducial_cl = (
                     get_theo_c_ell(
                         ell=ell,
@@ -181,7 +179,7 @@ class PseudoClMixin:
                 # Load data and create shear and noise maps
                 cat_gal = fits.getdata(self.cc[ver]["shear"]["path"])
 
-                n_gal, unique_pix, idx, idx_rep = self.get_n_gal_map(
+                n_gal, unique_pix, _idx, idx_rep = self.get_n_gal_map(
                     params, nside, cat_gal
                 )
 
@@ -202,14 +200,7 @@ class PseudoClMixin:
                         idx_rep,
                     )
 
-                    cl_noise = np.mean(cl_noise, axis=0)
-                    noise_bias_cl = cl_noise
-                    noise_bias_cl = b.unbin_cell(noise_bias_cl)  # Unbin
-                    lowest_ell = b.get_ell_list(0)[0]
-                    for i in range(4):
-                        noise_bias_cl[i, :lowest_ell] = noise_bias_cl[
-                            i, lowest_ell
-                        ]  # Fill the data vector below lmin
+                    noise_bias_cl = np.mean(cl_noise, axis=0)
 
                 elif self.noise_bias_method == "analytic":
                     self.print_cyan("Getting analytic noise bias.")
@@ -230,17 +221,16 @@ class PseudoClMixin:
                     noise_bias_cl[3, :] = noise_bias
 
                     noise_bias_cl = wsp.decouple_cell(noise_bias_cl)  # Decouple
-                    noise_bias_cl = b.unbin_cell(noise_bias_cl)  # Unbin
-                    lowest_ell = b.get_ell_list(0)[0]
-                    for i in range(4):
-                        noise_bias_cl[i, :lowest_ell] = noise_bias_cl[
-                            i, lowest_ell
-                        ]  # Fill the data vector below lmin
 
                 else:
                     raise ValueError(
                         f"Noise bias method {self.noise_bias_method} not recognized. It should be 'randoms' or 'analytic'."
                     )
+
+                # Unbin, then fill the data vector below lmin with the lowest-ell value
+                noise_bias_cl = b.unbin_cell(noise_bias_cl)
+                lowest_ell = b.get_ell_list(0)[0]
+                noise_bias_cl[:, :lowest_ell] = noise_bias_cl[:, [lowest_ell]]
 
                 self.print_cyan("Adding noise bias to the fiducial Cls.")
 
@@ -288,43 +278,21 @@ class PseudoClMixin:
                     wb=wsp,
                 ).reshape([n_ell_actual, 4, n_ell_actual, 4])
 
-                covar_EE_EE = covar_22_22[:, 0, :, 0]
-                covar_EE_EB = covar_22_22[:, 0, :, 1]
-                covar_EE_BE = covar_22_22[:, 0, :, 2]
-                covar_EE_BB = covar_22_22[:, 0, :, 3]
-                covar_EB_EE = covar_22_22[:, 1, :, 0]
-                covar_EB_EB = covar_22_22[:, 1, :, 1]
-                covar_EB_BE = covar_22_22[:, 1, :, 2]
-                covar_EB_BB = covar_22_22[:, 1, :, 3]
-                covar_BE_EE = covar_22_22[:, 2, :, 0]
-                covar_BE_EB = covar_22_22[:, 2, :, 1]
-                covar_BE_BE = covar_22_22[:, 2, :, 2]
-                covar_BE_BB = covar_22_22[:, 2, :, 3]
-                covar_BB_EE = covar_22_22[:, 3, :, 0]
-                covar_BB_EB = covar_22_22[:, 3, :, 1]
-                covar_BB_BE = covar_22_22[:, 3, :, 2]
-                covar_BB_BB = covar_22_22[:, 3, :, 3]
-
                 self.print_cyan("Saving Pseudo-Cl covariance")
 
+                # covar_22_22 is indexed [ell, pol_a, ell, pol_b]; store each of the
+                # 16 EE/EB/BE/BB cross-blocks as a named HDU (row-major pol order).
+                # Append rather than construct from a list so astropy promotes the
+                # first HDU to a PrimaryHDU on write.
+                pols = ["EE", "EB", "BE", "BB"]
                 hdu = fits.HDUList()
-
-                hdu.append(fits.ImageHDU(covar_EE_EE, name="COVAR_EE_EE"))
-                hdu.append(fits.ImageHDU(covar_EE_EB, name="COVAR_EE_EB"))
-                hdu.append(fits.ImageHDU(covar_EE_BE, name="COVAR_EE_BE"))
-                hdu.append(fits.ImageHDU(covar_EE_BB, name="COVAR_EE_BB"))
-                hdu.append(fits.ImageHDU(covar_EB_EE, name="COVAR_EB_EE"))
-                hdu.append(fits.ImageHDU(covar_EB_EB, name="COVAR_EB_EB"))
-                hdu.append(fits.ImageHDU(covar_EB_BE, name="COVAR_EB_BE"))
-                hdu.append(fits.ImageHDU(covar_EB_BB, name="COVAR_EB_BB"))
-                hdu.append(fits.ImageHDU(covar_BE_EE, name="COVAR_BE_EE"))
-                hdu.append(fits.ImageHDU(covar_BE_EB, name="COVAR_BE_EB"))
-                hdu.append(fits.ImageHDU(covar_BE_BE, name="COVAR_BE_BE"))
-                hdu.append(fits.ImageHDU(covar_BE_BB, name="COVAR_BE_BB"))
-                hdu.append(fits.ImageHDU(covar_BB_EE, name="COVAR_BB_EE"))
-                hdu.append(fits.ImageHDU(covar_BB_EB, name="COVAR_BB_EB"))
-                hdu.append(fits.ImageHDU(covar_BB_BE, name="COVAR_BB_BE"))
-                hdu.append(fits.ImageHDU(covar_BB_BB, name="COVAR_BB_BB"))
+                for i, pa in enumerate(pols):
+                    for j, pb in enumerate(pols):
+                        hdu.append(
+                            fits.ImageHDU(
+                                covar_22_22[:, i, :, j], name=f"COVAR_{pa}_{pb}"
+                            )
+                        )
 
                 hdu.writeto(out_path, overwrite=True)
 
@@ -565,7 +533,9 @@ class PseudoClMixin:
 
         w = cat_gal[params["w_col"]]
         self.print_cyan("Creating maps and computing Cl's...")
-        n_gal_map, unique_pix, idx, idx_rep = self.get_n_gal_map(params, nside, cat_gal)
+        n_gal_map, unique_pix, _idx, idx_rep = self.get_n_gal_map(
+            params, nside, cat_gal
+        )
         mask = n_gal_map != 0
 
         shear_map_e1 = np.zeros(hp.nside2npix(nside))

--- a/src/sp_validation/cosmo_val/psf_systematics.py
+++ b/src/sp_validation/cosmo_val/psf_systematics.py
@@ -103,10 +103,7 @@ class PSFSystematicsMixin:
         if survey in ("DES", "SP_axel_v0.0", "SP_axel_v0.0_repr"):
             params["patch_number"] = 120
             print("DES, jackknife patch number = 120")
-        elif survey == "SP_axel_v0.0":
-            params["patch_number"] = 120
-            print("SP_Axel_v0.0, jackknife patch number =120")
-        elif survey == "SP_v1.4-P3" or survey == "SP_v1.4-P3_LFmask":
+        elif survey in ("SP_v1.4-P3", "SP_v1.4-P3_LFmask"):
             params["patch_number"] = 120
             print("SP_v1.4, jackknife patch number =120")
         else:
@@ -176,11 +173,9 @@ class PSFSystematicsMixin:
 
             self.psf_fitter.load_rho_stat(f"rho_stats_{self.basename(ver)}.fits")
             nbins = self.psf_fitter.rho_stat_handler._treecorr_config["nbins"]
-            xi_psf_sys_samples = np.array([]).reshape(0, nbins)
-
-            for i in range(len(flat_samples)):
-                xi_psf_sys = self.psf_fitter.compute_xi_psf_sys(flat_samples[i])
-                xi_psf_sys_samples = np.vstack([xi_psf_sys_samples, xi_psf_sys])
+            xi_psf_sys_samples = np.array(
+                [self.psf_fitter.compute_xi_psf_sys(sample) for sample in flat_samples]
+            ).reshape(-1, nbins)
 
             self._xi_psf_sys[ver] = {
                 "mean": np.mean(xi_psf_sys_samples, axis=0),
@@ -567,35 +562,26 @@ class PSFSystematicsMixin:
         # Gather coefficients
         leakage_coeff = {}
         for ver in self.results_objectwise:
-            leakage_coeff[ver] = {}
             results = self.results[ver]
-            results_obj = self.results_objectwise[ver]
-            # Object-wise leakage
-            leakage_coeff[ver]["a11"] = ufloat(
-                results_obj.par_best_fit["a11"].value,
-                results_obj.par_best_fit["a11"].stderr,
-            )
-            leakage_coeff[ver]["a22"] = ufloat(
-                results_obj.par_best_fit["a22"].value,
-                results_obj.par_best_fit["a22"].stderr,
-            )
-            leakage_coeff[ver]["aii_mean"] = 0.5 * (
-                leakage_coeff[ver]["a11"] + leakage_coeff[ver]["a22"]
-            )
+            par_best_fit = self.results_objectwise[ver].par_best_fit
 
-            # Scale-dependent leakage: mean
-            leakage_coeff[ver]["alpha_mean"] = ufloat(
-                results.alpha_leak_mean, results.alpha_leak_std
-            )
-            # Scale-dependent leakage: value at smallest scale
-            leakage_coeff[ver]["alpha_1"] = ufloat(
-                results.alpha_leak[0], results.sig_alpha_leak[0]
-            )
-            # Scale-dependent leakage: value extrapolated to 0 using affine model
-            leakage_coeff[ver]["alpha_0"] = ufloat(
-                results.alpha_affine_best_fit["c"].value,
-                results.alpha_affine_best_fit["c"].stderr,
-            )
+            # Object-wise leakage
+            a11 = ufloat(par_best_fit["a11"].value, par_best_fit["a11"].stderr)
+            a22 = ufloat(par_best_fit["a22"].value, par_best_fit["a22"].stderr)
+            leakage_coeff[ver] = {
+                "a11": a11,
+                "a22": a22,
+                "aii_mean": 0.5 * (a11 + a22),
+                # Scale-dependent leakage: mean
+                "alpha_mean": ufloat(results.alpha_leak_mean, results.alpha_leak_std),
+                # Scale-dependent leakage: value at smallest scale
+                "alpha_1": ufloat(results.alpha_leak[0], results.sig_alpha_leak[0]),
+                # Scale-dependent leakage: value extrapolated to 0 using affine model
+                "alpha_0": ufloat(
+                    results.alpha_affine_best_fit["c"].value,
+                    results.alpha_affine_best_fit["c"].stderr,
+                ),
+            }
 
         self.leakage_coeff = leakage_coeff
 

--- a/src/sp_validation/cosmo_val/pure_eb.py
+++ b/src/sp_validation/cosmo_val/pure_eb.py
@@ -127,11 +127,11 @@ class PureEBMixin:
         gg_int = self.calculate_2pcf(version, npatch=npatch, **treecorr_config_int)
 
         # Get redshift distribution if using analytic covariance
-        if cov_path_int is not None:
-            z, nz = self.get_redshift(version)
-            z_dist = np.column_stack([z, nz])
-        else:
-            z_dist = None
+        z_dist = (
+            np.column_stack(self.get_redshift(version))
+            if cov_path_int is not None
+            else None
+        )
 
         # Delegate to b_modes module
         results = calculate_pure_eb_correlation(
@@ -282,7 +282,7 @@ class PureEBMixin:
                 n_samples=n_samples,
             )
 
-            # Calculate E/B statistics for all bin combinations (only if not provided)
+            # Calculate E/B statistics for all bin combinations
             version_results = calculate_eb_statistics(
                 version_results,
                 cov_path_int=cov_path_int,

--- a/src/sp_validation/cosmo_val/real_space.py
+++ b/src/sp_validation/cosmo_val/real_space.py
@@ -197,7 +197,7 @@ class RealSpaceMixin:
 
     def plot_2pcf(self):
         # Plot of n_pairs
-        fig, ax = plt.subplots(ncols=1, nrows=1)
+        plt.subplots(ncols=1, nrows=1)
         for ver in self.versions:
             self.calculate_2pcf(ver)
             plt.plot(
@@ -216,7 +216,7 @@ class RealSpaceMixin:
         self.print_done(f"n_pair plot saved to {out_path}")
 
         # Plot of xi_+
-        fig, _ = plt.subplots(ncols=1, nrows=1, figsize=(7, 7))
+        plt.subplots(ncols=1, nrows=1, figsize=(7, 7))
         for idx, ver in enumerate(self.versions):
             plt.errorbar(
                 self.cat_ggs[ver].meanr * cs_plots.dx(idx, fx=1.05, nx=len(ver)),
@@ -239,7 +239,7 @@ class RealSpaceMixin:
         self.print_done(f"xi_plus plot saved to {out_path}")
 
         # Plot of xi_-
-        fig, _ = plt.subplots(ncols=1, nrows=1, figsize=(7, 7))
+        plt.subplots(ncols=1, nrows=1, figsize=(7, 7))
         for idx, ver in enumerate(self.versions):
             plt.errorbar(
                 self.cat_ggs[ver].meanr * cs_plots.dx(idx, fx=1.05, nx=len(ver)),
@@ -262,7 +262,7 @@ class RealSpaceMixin:
         self.print_done(f"xi_minus plot saved to {out_path}")
 
         # Plot of xi_+(theta) * theta
-        fig, _ = plt.subplots(ncols=1, nrows=1, figsize=(7, 7))
+        plt.subplots(ncols=1, nrows=1, figsize=(7, 7))
         for idx, ver in enumerate(self.versions):
             plt.errorbar(
                 self.cat_ggs[ver].meanr,
@@ -284,7 +284,7 @@ class RealSpaceMixin:
         self.print_done(f"xi_plus_theta plot saved to {out_path}")
 
         # Plot of xi_- * theta
-        fig, _ = plt.subplots(ncols=1, nrows=1, figsize=(7, 7))
+        plt.subplots(ncols=1, nrows=1, figsize=(7, 7))
         for idx, ver in enumerate(self.versions):
             plt.errorbar(
                 self.cat_ggs[ver].meanr * cs_plots.dx(idx, len(ver)),
@@ -309,7 +309,7 @@ class RealSpaceMixin:
         # but skip if xi_psf_sys is not calculated since that takes forever
         if hasattr(self, "_xi_psf_sys"):
             for idx, ver in enumerate(self.versions):
-                fig, _ = plt.subplots(ncols=1, nrows=1, figsize=(7, 7))
+                plt.subplots(ncols=1, nrows=1, figsize=(7, 7))
                 plt.errorbar(
                     self.cat_ggs[ver].meanr * cs_plots.dx(idx, len(ver)),
                     self.cat_ggs[ver].xip,
@@ -354,7 +354,7 @@ class RealSpaceMixin:
 
     def plot_ratio_xi_sys_xi(self, threshold=0.1, offset=0.02):
 
-        fig, _ = plt.subplots(ncols=1, nrows=1, figsize=(10, 7))
+        plt.subplots(ncols=1, nrows=1, figsize=(10, 7))
 
         for idx, ver in enumerate(self.versions):
             self.calculate_2pcf(ver)
@@ -497,19 +497,12 @@ class RealSpaceMixin:
 
     def plot_aperture_mass_dispersion(self):
         for mode in ["mapsq", "mapsq_im", "mxsq", "mxsq_im"]:
-            x = []
-            y = []
-            yerr = []
-            labels = []
-            colors = []
-            linestyles = []
-            for ver in self.versions:
-                x.append(self.map2["theta_map"])
-                y.append(self.map2[ver][mode])
-                yerr.append(np.sqrt(self.map2[ver]["varmapsq"]))
-                labels.append(ver)
-                colors.append(self.cc[ver]["colour"])
-                linestyles.append(self.cc[ver]["ls"])
+            x = [self.map2["theta_map"] for ver in self.versions]
+            y = [self.map2[ver][mode] for ver in self.versions]
+            yerr = [np.sqrt(self.map2[ver]["varmapsq"]) for ver in self.versions]
+            labels = list(self.versions)
+            colors = [self.cc[ver]["colour"] for ver in self.versions]
+            linestyles = [self.cc[ver]["ls"] for ver in self.versions]
 
             xlabel = r"$\theta$ [arcmin]"
             ylabel = "dispersion"
@@ -536,13 +529,9 @@ class RealSpaceMixin:
             self.print_done(f"linear-scale {mode} plot saved to {out_path}")
 
         for mode in ["mapsq", "mapsq_im", "mxsq", "mxsq_im"]:
-            x = []
-            y = []
-            yerr = []
-            for ver in self.versions:
-                x.append(self.map2["theta_map"])
-                y.append(np.abs(self.map2[ver][mode]))
-                yerr.append(np.sqrt(self.map2[ver]["varmapsq"]))
+            x = [self.map2["theta_map"] for ver in self.versions]
+            y = [np.abs(self.map2[ver][mode]) for ver in self.versions]
+            yerr = [np.sqrt(self.map2[ver]["varmapsq"]) for ver in self.versions]
             xlabel = r"$\theta$ [arcmin]"
             ylabel = "dispersion"
             title = f"Aperture-mass dispersion mode {mode}"


### PR DESCRIPTION
## What

A cleanup pass over the freshly-split `cosmo_val/` package — dead code, duplication, and verbose constructs tightened across all seven modules. **−62 lines net, no functionality change.** Each module's diff was checked by an independent reviewer that reverted anything not provably behavior-preserving, and the whole thing is gated on the value-drift suite staying green.

Representative changes:

- Dead-variable removals (`fig, _ = plt.subplots()` → `plt.subplots()` where the handle was unused).
- `.append()` loops → list comprehensions; `if/else` assignment → ternary; `yaml.load(f.read())` → stream.
- A wrong assertion message corrected (`noise_bias_method` printed "analytical" while the check uses "analytic").
- Import hoisting and local-name tidy.

## What it deliberately did not touch

Public method names and signatures (every call site is unchanged), and the numerical internals of the diagnostics the value-drift suite does **not** pin (rho/tau, leakage, 2PCF, aperture-mass) — those got only unambiguously-safe edits.

## Verification

`ruff check src/sp_validation` clean. The value-drift suite (`test_cosmo_val.py`, `test_b_modes.py`) stays green in the fresh sandbox — every scientific pin holds.

Stacked on #207. Draft for review.

— Claude on behalf of Cail
