### PR TITLE
TEST: lint gate demo — DO NOT MERGE (auto-cleanup)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,8 +38,8 @@ name: Lint
 on:
   push:
     branches: [develop]
-  pull_request_target:
-    branches: [test/lint-gate-base]
+  pull_request:        # TEST ONLY (throwaway branch): pull_request reads the
+                       # workflow from the PR head, so it actually fires pre-merge
   workflow_dispatch:
 
 # One lint run per branch / PR; newer pushes cancel older in-flight runs.
@@ -118,7 +118,7 @@ jobs:
             const report = passed ? '' : fs.readFileSync('report.md', 'utf8');
 
             // ---- PR: speak on the PR itself (comment, auto-updating) ----------
-            if (context.eventName === 'pull_request_target') {
+            if (context.eventName === 'pull_request_target' || context.eventName === 'pull_request') {
               const pr = context.payload.pull_request;
               const author = pr.user.login;
               const MARKER = '<!-- ruff-lint-gate -->';

--- a/_lint_gate_demo.py
+++ b/_lint_gate_demo.py
@@ -1,0 +1,7 @@
+"""Throwaway file to demo the develop lint gate. Delete me."""
+
+import os  # F401: unused import
+
+
+def demo():
+    return undefined_thing + 1  # F821: undefined name

--- a/_lint_gate_demo.py
+++ b/_lint_gate_demo.py
@@ -1,7 +1,0 @@
-"""Throwaway file to demo the develop lint gate. Delete me."""
-
-import os  # F401: unused import
-
-
-def demo():
-    return undefined_thing + 1  # F821: undefined name


### PR DESCRIPTION
Throwaway PR to demo the develop lint-gate's PR-comment behavior against a deliberate ruff violation. Base branch only changes the pull_request_target trigger filter; head adds a file with F401 + F821. Will be closed and both branches deleted after the demo. — Claude on behalf of Cail