### PR TITLE
Blinding dependencies as core: Smokescreen fork pin, sacc, cryptography; Python floor 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,11 @@ dependencies = [
     "camb>=1.6",
     "clmm",
     "colorama",
+    # Blinding closure (core, no extra): cryptography + sacc here, plus the
+    # Smokescreen fork pin below; pyccl (the theory backend) is already core.
+    # cryptography and sacc are declared explicitly so the core runtime
+    # closure is self-documenting and independent of fork-metadata drift.
+    "cryptography",
     # Track cs_util's develop branch directly (git dependency) rather than a
     # PyPI pin: the two repos are iterating together heavily and cs_util
     # releases are infrequent. This PR's cosmology repoint needs get_cosmo /
@@ -74,6 +79,7 @@ dependencies = [
     "pymaster",
     "regions",
     "reproject",
+    "sacc>=0.12",
     # scipy 1.18 ported FITPACK from Fortran to C, changing the return shape of
     # RectBivariateSpline(scalar, scalar, grid=False) from 0-d `array(x)` to
     # shape-(1,) `array([x])`. camb's BBN Y_He predictor (bbn.py) wraps the
@@ -91,6 +97,12 @@ dependencies = [
     # getdist feature-branch below, which is an external fork we pin for repro.)
     "shear_psf_leakage @ git+https://github.com/CosmoStat/shear_psf_leakage.git@develop",
     "skyproj",
+    # UNIONS-WL fork of DESC Smokescreen, pinned by SHA on the fork's
+    # packaging branch: it declares pyccl and imports its theory backends
+    # lazily, so the install closure is CCL-only. Provisional pin — swapped to the
+    # fork's release tag once the fork packaging PRs merge. Git pin only;
+    # nothing is published to PyPI.
+    "smokescreen @ git+https://github.com/UNIONS-WL/Smokescreen@588a6b9b26560bd5ba3dd5ba342f3c40152644f9",
     "statsmodels",
     "treecorr>=5.0",
     "tqdm",

--- a/uv.lock
+++ b/uv.lock
@@ -795,6 +795,15 @@ wheels = [
 ]
 
 [[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
 name = "docutils"
 version = "0.22.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1337,6 +1346,15 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-resources"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/06/b56dfa750b44e86157093bc8fca0ab81dccbf5260510de4eaf1cb69b5b99/importlib_resources-7.1.0.tar.gz", hash = "sha256:0722d4c6212489c530f2a145a34c0a7a3b4721bc96a15fada5930e2a0b760708", size = 44985, upload-time = "2026-04-12T16:36:09.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/db/55a262f3606bebcae07cc14095338471ad7c0bbcaa37707e6f0ee49725b7/importlib_resources-7.1.0-py3-none-any.whl", hash = "sha256:1bd7b48b4088eddb2cd16382150bb515af0bd2c70128194392725f82ad2c96a1", size = 37232, upload-time = "2026-04-12T16:36:08.219Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1520,6 +1538,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e4/7d/05c46a96a78147ae3bf99c2f4169ce144a70220b8d6fcd56f6ec368b8ce9/json5-0.15.0.tar.gz", hash = "sha256:7424d1f1eb1d56da6e3d70643f53619862b4ce81440bdb8ecfd6f875e5ba4a71", size = 53278, upload-time = "2026-06-19T20:08:27.716Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/be/59527c99478aade6bb33a68d72e6e18dd4e6ff6eacfc7d01bdb15bc76912/json5-0.15.0-py3-none-any.whl", hash = "sha256:56636a30c0e8a4665fe2179c0212f32eae3796dea89ea6f649b9436ecdb39618", size = 36570, upload-time = "2026-06-19T20:08:26.748Z" },
+]
+
+[[package]]
+name = "jsonargparse"
+version = "4.49.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/0b/f012466077d803b546955bf827ab30a320ad1550e3167195432cc2d6bfad/jsonargparse-4.49.0.tar.gz", hash = "sha256:9e691a09d937fb4c6bc1f6d3bf6c3546efa03381ea1e64ee10759095f1b14da7", size = 125237, upload-time = "2026-05-15T06:48:44.807Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/64/51cbc9044f5b1ee4fb9894fe791f50dfdb52dc080acfafb5818ba19e8c27/jsonargparse-4.49.0-py3-none-any.whl", hash = "sha256:2025880765fd792f6fb9861aa93f26da5f6c350be5d7656321369b22b0d2538e", size = 134834, upload-time = "2026-05-15T06:48:40.76Z" },
+]
+
+[package.optional-dependencies]
+signatures = [
+    { name = "docstring-parser", marker = "sys_platform == 'linux'" },
+    { name = "typeshed-client", marker = "sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -3305,6 +3341,20 @@ wheels = [
 ]
 
 [[package]]
+name = "sacc"
+version = "2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "astropy", marker = "sys_platform == 'linux'" },
+    { name = "numpy", marker = "sys_platform == 'linux'" },
+    { name = "scipy", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b6/82/5b603d960279b8eb7fac677ba3550c0903a8390f1bff2eee6fbfa59765da/sacc-2.4.tar.gz", hash = "sha256:a98fb4e59b3c742ddb492a15a10e1f8a4279ba36d56c0d3c35e1cd13cca1167b", size = 424905, upload-time = "2026-07-02T11:29:27.458Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/9f/56288a8aabafa24679d32d01e7db732e8e89e4074cc91aedc0bb7b7c8e46/sacc-2.4-py3-none-any.whl", hash = "sha256:da6b648998738c7c307cbdff644429633726844f8c048642725be5efc1859fa3", size = 50931, upload-time = "2026-07-02T11:29:26.286Z" },
+]
+
+[[package]]
 name = "scipy"
 version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3467,6 +3517,20 @@ wheels = [
 ]
 
 [[package]]
+name = "smokescreen"
+version = "1.5.6"
+source = { git = "https://github.com/UNIONS-WL/Smokescreen?rev=588a6b9b26560bd5ba3dd5ba342f3c40152644f9#588a6b9b26560bd5ba3dd5ba342f3c40152644f9" }
+dependencies = [
+    { name = "astropy", marker = "sys_platform == 'linux'" },
+    { name = "cryptography", marker = "sys_platform == 'linux'" },
+    { name = "jsonargparse", extra = ["signatures"], marker = "sys_platform == 'linux'" },
+    { name = "numpy", marker = "sys_platform == 'linux'" },
+    { name = "pyccl", marker = "sys_platform == 'linux'" },
+    { name = "sacc", marker = "sys_platform == 'linux'" },
+    { name = "scipy", marker = "sys_platform == 'linux'" },
+]
+
+[[package]]
 name = "snakemake"
 version = "9.23.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3617,6 +3681,7 @@ dependencies = [
     { name = "clmm", marker = "sys_platform == 'linux'" },
     { name = "colorama", marker = "sys_platform == 'linux'" },
     { name = "cosmo-numba", marker = "sys_platform == 'linux'" },
+    { name = "cryptography", marker = "sys_platform == 'linux'" },
     { name = "cs-util", marker = "sys_platform == 'linux'" },
     { name = "emcee", marker = "sys_platform == 'linux'" },
     { name = "getdist", marker = "sys_platform == 'linux'" },
@@ -3632,7 +3697,6 @@ dependencies = [
     { name = "lmfit", marker = "sys_platform == 'linux'" },
     { name = "matplotlib", marker = "sys_platform == 'linux'" },
     { name = "numba", marker = "sys_platform == 'linux'" },
-    { name = "numexpr", marker = "sys_platform == 'linux'" },
     { name = "numpy", marker = "sys_platform == 'linux'" },
     { name = "opencv-python-headless", marker = "sys_platform == 'linux'" },
     { name = "pandas", marker = "sys_platform == 'linux'" },
@@ -3642,10 +3706,12 @@ dependencies = [
     { name = "pyyaml", marker = "sys_platform == 'linux'" },
     { name = "regions", marker = "sys_platform == 'linux'" },
     { name = "reproject", marker = "sys_platform == 'linux'" },
+    { name = "sacc", marker = "sys_platform == 'linux'" },
     { name = "scipy", marker = "sys_platform == 'linux'" },
     { name = "seaborn", marker = "sys_platform == 'linux'" },
     { name = "shear-psf-leakage", marker = "sys_platform == 'linux'" },
     { name = "skyproj", marker = "sys_platform == 'linux'" },
+    { name = "smokescreen", marker = "sys_platform == 'linux'" },
     { name = "statsmodels", marker = "sys_platform == 'linux'" },
     { name = "tqdm", marker = "sys_platform == 'linux'" },
     { name = "treecorr", marker = "sys_platform == 'linux'" },
@@ -3695,6 +3761,7 @@ requires-dist = [
     { name = "colorama" },
     { name = "cosmo-numba", git = "https://github.com/aguinot/cosmo-numba.git?rev=main" },
     { name = "cosmology", marker = "extra == 'glass'", specifier = "==2022.10.9" },
+    { name = "cryptography" },
     { name = "cs-util", git = "https://github.com/CosmoStat/cs_util.git?rev=develop" },
     { name = "emcee" },
     { name = "fitsio", marker = "extra == 'glass'" },
@@ -3715,7 +3782,6 @@ requires-dist = [
     { name = "mpi4py", marker = "extra == 'workflow'" },
     { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=4.0" },
     { name = "numba" },
-    { name = "numexpr" },
     { name = "numpy", specifier = ">=2.0" },
     { name = "numpydoc", marker = "extra == 'docs'", specifier = ">=1.8" },
     { name = "opencv-python-headless" },
@@ -3729,10 +3795,12 @@ requires-dist = [
     { name = "regions" },
     { name = "reproject" },
     { name = "ruff", marker = "extra == 'test'" },
+    { name = "sacc", specifier = ">=0.12" },
     { name = "scipy", specifier = "<1.18" },
     { name = "seaborn" },
     { name = "shear-psf-leakage", git = "https://github.com/CosmoStat/shear_psf_leakage.git?rev=develop" },
     { name = "skyproj" },
+    { name = "smokescreen", git = "https://github.com/UNIONS-WL/Smokescreen?rev=588a6b9b26560bd5ba3dd5ba342f3c40152644f9" },
     { name = "snakemake", marker = "extra == 'workflow'" },
     { name = "sp-validation", extras = ["test", "docs"], marker = "extra == 'develop'" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=8.0" },
@@ -4152,6 +4220,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6f/bb/5ba5aa1021fce0cf459fa264cb0d298dfd095ddb48d63fb6589b90fdefac/treecorr-5.1.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:660dacd47a9af18790de279bcb6e7f375369096ad77e7cc64bf21a9b78f6c430", size = 19785388, upload-time = "2026-03-18T18:37:40.573Z" },
     { url = "https://files.pythonhosted.org/packages/be/92/be01211263a4fa488e768c9288c6f9b0f4402870423a88de4d60031b3384/treecorr-5.1.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:73c938c6c31e1bad4d5338ad4519d1d78eedf3b7ef579b1e3a19d983e220ed93", size = 20940568, upload-time = "2026-03-18T18:37:44.966Z" },
     { url = "https://files.pythonhosted.org/packages/dc/a3/69e5a16aa33600ba22d28a47c6d8de3b3118292e79f9ae77dc69a3df7c77/treecorr-5.1.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dc17b1f623bae6769148f57cac8c3a295e26e5d6215698117bd97e14c8bb0d6b", size = 19781991, upload-time = "2026-03-18T18:37:47.468Z" },
+]
+
+[[package]]
+name = "typeshed-client"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-resources", marker = "sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/5d/97d6fa8c204b0d42be931e7a568b306cda43f93ff45f8b47537ee61390de/typeshed_client-2.12.0.tar.gz", hash = "sha256:54dcfa25fcff82cedcb1b51c03c1b3c51a614097aab8fe49e4316aff6f79d9c7", size = 529457, upload-time = "2026-06-02T04:00:51.51Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/98/3aef1587ec9b3a5cd062b8d8910545a0ee3715c31fd65b1f2386b27b94af/typeshed_client-2.12.0-py3-none-any.whl", hash = "sha256:da3ef54a0e60c0f45f59006b73a3cb20b1acbf7a784e982476d8193e8828ddf5", size = 796929, upload-time = "2026-06-02T04:00:49.643Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Makes the blinding dependencies installable and reproducible as **core** runtime dependencies of sp_validation — blinding needs Smokescreen with its CCL theory backend, and with firecrown out of the picture the closure is small (Smokescreen fork + `cryptography` + `sacc`; `pyccl` already core), so it lives in the base install with no `[blinding]` extra.

Closes #242.

## What this PR declares

- **Smokescreen**, pinned as a single git install identity into the UNIONS-WL fork:
  `smokescreen @ git+https://github.com/UNIONS-WL/Smokescreen@588a6b9`
  The fork at this ref declares `pyccl` and imports its theory backends lazily, so the resolved graph is CCL-only — no firecrown, no numpy ceiling. Nothing is published to PyPI; the fork ships as a git pin only. **Provisional pin:** the SHA points at the fork's packaging branch; it will be swapped to the fork's release tag (same content, stable name) before merge.
- **`sacc>=0.12`** and **`cryptography`**, explicit in core `dependencies`, so the runtime closure is self-documenting and independent of fork-metadata drift.
- **`uv.lock`** regenerated against the new closure.

Dockerfile and CI are unchanged: the closure is core, so the existing install line covers it, and an install failure of the fork pin already fails the image build.

## Verified

On Python 3.12, a fresh `uv venv` + `uv pip install -e .` resolves without firecrown and without any numpy upper bound, and `import smokescreen` succeeds in the installed environment. `uv lock` resolves the fork ref cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QWF72ofwJh6ekgnCt9Xx6C