### PR TITLE
lint gate: server-side ruff autofix for same-repo PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,21 +1,34 @@
 name: Lint
 
-# Lint gate for `develop` — warn locally, account here.
+# Lint gate for `develop` — warn locally, fix-and-account here.
 #
-# The model (settled with Cail + Sacha, 2026-06-23/30):
+# The model (settled with Cail + Sacha, 2026-06-23/30; autofix added 2026-07-10):
 #   * Locally, ruff auto-applies safe fixes and only WARNS on the rest (see
 #     .pre-commit-config.yaml) — you commit freely.
 #   * Getting into `develop` is gated. This job runs the FULL ruff policy
-#     (`ruff check .` + `ruff format --check .`, region-aware per pyproject.toml)
-#     and on any failure it (1) fails the job RED so the check blocks the merge,
-#     and (2) tells the author what to fix — in the surface that fits the event:
-#       - On a PR  → posts/updates a COMMENT on the PR itself, with the full
-#         violation list (and ruff annotations in the run's Checks view). The
-#         author sees it where they already are; no disconnected issue. The
-#         comment turns green when ruff passes.
-#       - On a direct push to develop → there's no PR to comment on, so it opens
-#         (or updates) ONE lint-debt issue for the committer, @-mentioning and
-#         assigning them. Auto-closes when their next push is clean.
+#     (`ruff check .` + `ruff format --check .`, region-aware per pyproject.toml).
+#     What happens next depends on the event:
+#
+#     - On a same-repo PR (head branch lives in THIS repo, not a fork) → the gate
+#       doesn't just report; it FIXES. If the first pass isn't clean it runs
+#       `ruff check --fix-only` + `ruff format`, commits the diff as the
+#       github-actions bot, and pushes it back to the PR branch. Then it re-runs
+#       ruff on the fixed tree IN THE SAME RUN and gates on THAT: if formatting +
+#       safe fixes cleaned everything → job GREEN, comment says autofix was
+#       pushed; if anything survives (unsafe/judgement lint — undefined names,
+#       unused vars) → job RED, comment lists ONLY the residual (the mechanical
+#       stuff is already fixed). Contributors mostly never touch ruff by hand.
+#
+#     - On a fork PR (read-only token, can't push to the fork's branch) → the old
+#       behaviour: run the checks, and on failure (1) fail RED so the check blocks
+#       the merge, (2) post/update a COMMENT on the PR with the full violation
+#       list. The comment turns green when ruff passes.
+#
+#     - On a direct push to develop → there's no PR to comment on, so on failure
+#       it opens (or updates) ONE lint-debt issue for the committer, @-mentioning
+#       and assigning them. Auto-closes when their next push is clean. (No autofix
+#       here — pushing a bot commit onto develop would be its own event.)
+#
 #   * If ruff itself can't run (network, bad version), the job goes red but says
 #     nothing — that's infra, not the committer's lint debt.
 #
@@ -23,17 +36,25 @@ name: Lint
 # branches stay quiet (too noisy otherwise). `workflow_dispatch` is for manual
 # testing of the gate itself.
 #
-# Why `pull_request_target` for PRs: commenting on a PR needs a write token, and
-# PRs from forks (e.g. sachaguer/) get a read-only token under the plain
-# `pull_request` event. `pull_request_target` runs this workflow from the BASE
-# branch (so the workflow definition is trusted) with a write token, while we
-# check out the PR head ONLY to lint it. Two hardening measures make running
-# tooling over untrusted PR code safe here: ruff is a static analyzer (it parses
-# files, never imports/executes them), and `uvx --no-config` makes uv ignore any
-# `uv.toml`/`[tool.uv]` in the PR tree, so a malicious PR can't redirect ruff's
-# download to a trojaned index. The checkout also drops its git credentials.
-# (A PR can still edit `[tool.ruff]` to weaken its own policy, but that's visible
-# in the diff and reviewed like any other change.)
+# Why `pull_request_target` for PRs: commenting on (and pushing to) a PR needs a
+# write token, and PRs from forks (e.g. sachaguer/) get a read-only token under
+# the plain `pull_request` event. `pull_request_target` runs this workflow from
+# the BASE branch (so the workflow definition is trusted) with a write token,
+# while we check out the PR head ONLY to lint it. Two hardening measures make
+# running tooling over untrusted PR code safe here: ruff is a static analyzer (it
+# parses files, never imports/executes them), and `uvx --no-config` makes uv
+# ignore any `uv.toml`/`[tool.uv]` in the PR tree, so a malicious PR can't
+# redirect ruff's download to a trojaned index. The checkout also drops its git
+# credentials. (A PR can still edit `[tool.ruff]` to weaken its own policy, but
+# that's visible in the diff and reviewed like any other change.)
+#
+# Why the autofix push is safe under pull_request_target: we run ONLY ruff over
+# the untrusted tree (static, never executes PR code), and we push back ONLY the
+# diff ruff itself produced — no PR-authored script runs with our write token.
+# The push uses the workflow token explicitly (the checkout keeps
+# persist-credentials: false), and a GITHUB_TOKEN push does NOT trigger a new
+# workflow run — so no recursion, but also no fresh CI on the bot commit, which
+# is exactly why we re-lint and gate in THIS run rather than waiting for a rerun.
 
 on:
   push:
@@ -48,7 +69,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
+  contents: write        # push ruff autofix commit back to a same-repo PR branch
   issues: write          # develop-push lint-debt issue
   pull-requests: write   # PR lint comment
 
@@ -66,6 +87,19 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v3
+
+      # Is this a PR whose head branch lives in THIS repo (not a fork)? Only then
+      # can we push an autofix commit back to it with the workflow token.
+      - name: Decide whether autofix can push
+        id: mode
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request_target" ] && \
+             [ "${{ github.event.pull_request.head.repo.full_name }}" = "${{ github.repository }}" ]; then
+            echo "autofix=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "autofix=false" >> "$GITHUB_OUTPUT"
+          fi
 
       # Run the checks WITHOUT failing the step — we post feedback before turning
       # the job red. `ruff@<pin>` matches the pre-commit version; `--no-config`
@@ -102,20 +136,109 @@ jobs:
             echo "passed=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # ── Autofix (same-repo PRs only) ──────────────────────────────────────────
+      # The first pass found something on a branch we can push to: apply ruff's
+      # own fixes (safe lint fixes + formatting), commit the diff as the bot, and
+      # push it back. SAFE under pull_request_target: only ruff runs over the PR
+      # tree (static, never executes it), and only ruff's own diff is pushed — no
+      # PR-authored code touches our write token. Then re-lint the FIXED tree in
+      # this same run: a GITHUB_TOKEN push doesn't trigger a new workflow, so the
+      # residual pass/fail we compute here is what the gate reports.
+      - name: Ruff autofix + push (same-repo PR)
+        id: autofix
+        if: >-
+          steps.mode.outputs.autofix == 'true' &&
+          steps.ruff.outputs.tool_error == 'false' &&
+          steps.ruff.outputs.passed == 'false'
+        shell: bash
+        run: |
+          # `check --fix-only` exits 1 when unfixable violations remain even
+          # after applying every safe fix, so don't let that abort the step.
+          uvx --no-config ruff@0.15.18 check --fix-only . || true
+          uvx --no-config ruff@0.15.18 format . || true
+
+          set -e
+          if git diff --quiet; then
+            # ruff couldn't fix anything (all issues are unsafe/judgement calls):
+            # nothing to push. The gate falls back to the first-pass result and
+            # the original report already lists these — no autofix comment.
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git config user.name  'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add -A
+          git commit -m "ruff autofix (format + safe lint fixes)" \
+                     -m "Pushed by the lint gate."
+
+          # Push back to the PR HEAD branch. The checkout kept
+          # persist-credentials: false, so authenticate the push explicitly with
+          # the workflow token via the remote URL.
+          BRANCH='${{ github.event.pull_request.head.ref }}'
+          REPO='${{ github.event.pull_request.head.repo.full_name }}'
+          git push "https://x-access-token:${{ github.token }}@github.com/${REPO}.git" "HEAD:${BRANCH}"
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "pushed=true" >> "$GITHUB_OUTPUT"
+
+          # Re-lint the FIXED tree — this is what the gate reports (no rerun comes).
+          set +e
+          uvx --no-config ruff@0.15.18 check .          --output-format=concise > check2.txt  2>&1; check_rc=$?
+          uvx --no-config ruff@0.15.18 format --check .                        > format2.txt 2>&1; fmt_rc=$?
+          set -e
+          {
+            echo "### Residual \`ruff check .\` (after autofix)"
+            if [ "$check_rc" -eq 0 ]; then echo; echo "✅ clean"; else echo; echo '```'; cat check2.txt; echo '```'; fi
+            echo
+            echo "### Residual \`ruff format --check .\` (after autofix)"
+            if [ "$fmt_rc" -eq 0 ]; then echo; echo "✅ clean"; else echo; echo '```'; cat format2.txt; echo '```'; fi
+          } > residual.md
+
+          if [ "$check_rc" -eq 0 ] && [ "$fmt_rc" -eq 0 ]; then
+            echo "residual_passed=true"  >> "$GITHUB_OUTPUT"
+          else
+            echo "residual_passed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Resolve the outcome the gate reports. For a same-repo PR that got an
+      # autofix push, the residual pass/fail on the FIXED tree supersedes the
+      # first pass (that's what's now on the branch); otherwise the first pass
+      # stands. `pushed`/`residual` are surfaced so the comment can say so.
+      - name: Resolve gate outcome
+        id: gate
+        if: steps.ruff.outputs.tool_error == 'false'
+        shell: bash
+        run: |
+          if [ "${{ steps.autofix.outputs.pushed }}" = "true" ]; then
+            echo "passed=${{ steps.autofix.outputs.residual_passed }}" >> "$GITHUB_OUTPUT"
+            echo "autofixed=true" >> "$GITHUB_OUTPUT"
+            echo "sha=${{ steps.autofix.outputs.sha }}" >> "$GITHUB_OUTPUT"
+            echo "report_file=residual.md" >> "$GITHUB_OUTPUT"
+          else
+            echo "passed=${{ steps.ruff.outputs.passed }}" >> "$GITHUB_OUTPUT"
+            echo "autofixed=false" >> "$GITHUB_OUTPUT"
+            echo "report_file=report.md" >> "$GITHUB_OUTPUT"
+          fi
+
       # Feedback is a side effect — never let it red a clean run.
       - name: Tell the author (PR comment) or record it (develop-push issue)
         if: steps.ruff.outputs.tool_error == 'false'
         continue-on-error: true
         uses: actions/github-script@v7
         env:
-          PASSED: ${{ steps.ruff.outputs.passed }}
+          PASSED: ${{ steps.gate.outputs.passed }}
+          AUTOFIXED: ${{ steps.gate.outputs.autofixed }}
+          AUTOFIX_SHA: ${{ steps.gate.outputs.sha }}
+          REPORT_FILE: ${{ steps.gate.outputs.report_file }}
         with:
           script: |
             const fs = require('fs');
             const passed = process.env.PASSED === 'true';
+            const autofixed = process.env.AUTOFIXED === 'true';
+            const autofixSha = (process.env.AUTOFIX_SHA || '').slice(0, 7);
             const { owner, repo } = context.repo;
             const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
-            const report = passed ? '' : fs.readFileSync('report.md', 'utf8');
+            const report = passed ? '' : fs.readFileSync(process.env.REPORT_FILE, 'utf8');
 
             // ---- PR: speak on the PR itself (comment, auto-updating) ----------
             if (context.eventName === 'pull_request_target') {
@@ -128,22 +251,35 @@ jobs:
               const mine = comments.find(c => c.body && c.body.includes(MARKER));
 
               if (passed) {
-                // Only update an existing comment to green; don't post on a PR
+                // Clean now. If we got here by pushing an autofix, say so (the
+                // push is why the branch changed under the author). Otherwise
+                // only update an existing comment to green — don't post on a PR
                 // that was never dirty.
+                const body = autofixed
+                  ? `🤖 **autofix pushed \`${autofixSha}\`, ruff is clean** — formatting and safe lint fixes were applied for you; nothing else to do. ${MARKER}`
+                  : `✅ **ruff is clean** — nothing to fix here. ${MARKER}`;
                 if (mine) {
-                  await github.rest.issues.updateComment({
-                    owner, repo, comment_id: mine.id,
-                    body: `✅ **ruff is clean** — nothing to fix here. ${MARKER}`,
-                  });
+                  await github.rest.issues.updateComment({ owner, repo, comment_id: mine.id, body });
+                } else if (autofixed) {
+                  await github.rest.issues.createComment({ owner, repo, issue_number: pr.number, body });
                 }
                 core.info('PR clean.');
                 return;
               }
 
+              const intro = autofixed
+                ? [
+                    `### 🔴 ruff — residual issues after autofix`,
+                    ``,
+                    `@${author} — I pushed \`${autofixSha}\` with the formatting and safe lint fixes, but these need a human and still block the merge into \`develop\`:`,
+                  ]
+                : [
+                    `### 🔴 ruff found lint / format issues`,
+                    ``,
+                    `@${author} — these block the merge into \`develop\`. Full list below (also surfaced as annotations in the CI run):`,
+                  ];
               const body = [
-                `### 🔴 ruff found lint / format issues`,
-                ``,
-                `@${author} — these block the merge into \`develop\`. Full list below (also surfaced as annotations in the CI run):`,
+                ...intro,
                 ``,
                 report,
                 ``,
@@ -233,8 +369,11 @@ jobs:
 
       # Red → blocks the merge. `always()` so a hiccup in the feedback step above
       # can't suppress the red on genuine lint debt; a tooling error also reds.
+      # A tooling error means `gate` was skipped (its outputs are empty), so test
+      # it first; otherwise the resolved gate outcome (post-autofix on same-repo
+      # PRs, first-pass elsewhere) decides.
       - name: Fail the job if the gate didn't pass
-        if: always() && steps.ruff.outputs.passed == 'false'
+        if: always() && (steps.ruff.outputs.tool_error == 'true' || steps.gate.outputs.passed == 'false')
         run: |
           if [ "${{ steps.ruff.outputs.tool_error }}" = "true" ]; then
             echo "::error::ruff could not run (network / version) — gate inconclusive, blocking."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,17 +70,26 @@ undefined names, unused variables, other judgement calls — is printed as a
 **warning** and never blocks the commit. Judgement-call lint stays out of your
 way locally; the gate below is where it's enforced.
 
-**`develop` is the gate.** On every push to `develop` and every PR into it, CI
-runs the full ruff policy. If it fails, the check goes **red and blocks the
-merge**, and the bot tells you what to fix where you already are:
+**`develop` is the gate — and on a PR it fixes for you.** On every push to
+`develop` and every PR into it, CI runs the full ruff policy.
 
-- **On a PR** → it posts (and keeps updating) a **comment on the PR** listing the
-  violations (also surfaced as annotations in the CI run). Push a fix and the
-  comment turns green.
+- **On a PR from a branch in this repo** → the gate doesn't just report, it
+  **fixes**: it runs `ruff format` + `ruff check --fix` and **pushes the result
+  back to your branch as the `github-actions` bot**, then re-checks. If that
+  cleaned everything, the PR comment goes green (`🤖 autofix pushed …, ruff is
+  clean`) and there's nothing to do — just `git pull` to pick up the commit. If
+  anything ruff *won't* safely fix survives (undefined names, unused variables,
+  other judgement calls), the check stays **red** and the comment lists **only
+  the residual** — the mechanical stuff is already handled. So you rarely touch
+  ruff by hand; when you do, it's the real judgement calls.
+- **On a PR from a fork** (where CI can't push to your branch) → it posts (and
+  keeps updating) a **comment on the PR** with the full violation list. Push a
+  fix and the comment turns green.
 - **On a direct push to `develop`** (no PR) → it opens (or updates) a single
   **lint-debt issue assigned to you**, which auto-closes when CI is green.
 
-So: warn while you work, clean before it lands.
+So: warn while you work, and for same-repo PRs the gate mostly cleans up after
+you before it lands.
 
 ## Commit hygiene (notebooks & large files)
 


### PR DESCRIPTION
## What

Extends the `develop` lint gate so that, on a PR whose head branch lives in **this** repo, it doesn't just report ruff violations — it **fixes the mechanical ones for you**.

When the first ruff pass on such a PR isn't clean, the gate:

1. runs `ruff check --fix-only .` + `ruff format .` over the PR head checkout,
2. commits the diff as the `github-actions[bot]` and **pushes it back to the PR branch** (message: `ruff autofix (format + safe lint fixes)`),
3. **re-lints the fixed tree in the same run** and gates on *that*:
   - fully clean → job **green**, PR comment: `🤖 autofix pushed <sha>, ruff is clean`;
   - residual unsafe/judgement lint (e.g. `F821` undefined name, unused vars) → job **red**, PR comment lists **only the residual**, noting the formatting/safe fixes were already pushed.

Fork PRs and direct `develop` pushes are **unchanged** (report-only: PR comment / lint-debt issue).

## The model

- Gated on `github.event.pull_request.head.repo.full_name == github.repository` — same-repo branches only, because only there can CI push back with the workflow token. Forks get the existing read-only behaviour.
- Adds `contents: write` to permissions (scoped comment in the workflow). Checkout keeps `persist-credentials: false`; the push authenticates explicitly via `x-access-token:${{ github.token }}` in the remote URL.

## Security (pull_request_target)

Running tooling over an untrusted PR tree is safe here because we run **only ruff** — a static analyzer that parses files but never imports/executes them — and we push back **only the diff ruff itself produced**. No PR-authored code runs with the write token. `uvx --no-config` still neutralizes any `uv.toml`/`[tool.uv]` in the PR tree.

## Two subtleties worth flagging for review

- **Fork limitation.** The autofix path can only fire on same-repo PRs; there is no way to push to a fork's branch from the base-repo workflow token. This is by design, and fork PRs keep the comment-based flow.
- **No retrigger.** A `GITHUB_TOKEN` push does **not** trigger a new workflow run — so there's no recursion, but also no fresh CI on the bot commit. That's exactly why the gate re-lints and decides pass/fail **within the same run** on the fixed tree, rather than waiting for a rerun that never comes.

## Verification

The gate runs the **base branch's** copy of the workflow, so this PR won't exercise its own changes. Verified instead by:

- **YAML parse** — valid; step graph as intended.
- **Local simulation of the exact ruff command sequence** (`ruff@0.15.18`, `--no-config`) against dirty fixtures, covering all three paths:
  - *fully fixable* (bad formatting + unused import) → autofix produces a diff, residual clean → `residual_passed=true` (green);
  - *residual* (bad formatting + `F821` undefined name) → autofix pushes formatting/safe fixes, `F821` survives → `residual_passed=false`, residual report lists only the `F821` (red);
  - *unfixable but already-formatted* (`F821` alone, clean formatting) → ruff produces no diff → `pushed=false`, gate falls back to the first-pass result with the original report (red).

Also updates the "Code style and the lint gate" section of `CONTRIBUTING.md` and the workflow's header comment block to describe the new model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)