### PR TITLE
Remove vestigial FHP/MK NOSHEAR←1P Tpsf substitution (guaranteed no-op)

### DIFF
--- a/scripts/calibration/calibrate_comprehensive_cat.py
+++ b/scripts/calibration/calibrate_comprehensive_cat.py
@@ -191,16 +191,6 @@ add_cols_data = {}
 for key in add_cols:
     add_cols_data[key] = cat.get_col(dat, key, mask_combined._mask, mask_metacal)
 
-# Keep original NOSHEAR column, override with 1P PSF values (FHP/MK hack)
-print(
-    "FHP/MK hack: explicit copying of the metacal no-shear (updated from 1p)"
-    + " PSF size"
-)
-add_cols_data["NGMIX_T_PSF_RECONV_NOSHEAR_orig"] = add_cols_data[
-    "NGMIX_T_PSF_RECONV_NOSHEAR"
-]
-add_cols_data["NGMIX_T_PSF_RECONV_NOSHEAR"] = gal_metacal.ns["Tpsf"][mask_metacal]
-
 # %%
 # Additional post-processing columns to write to output cat
 add_cols_post = [

--- a/src/sp_validation/calibration.py
+++ b/src/sp_validation/calibration.py
@@ -789,14 +789,6 @@ class metacal:
                 f"Unsupported shape prefix '{self._prefix}'; only 'NGMIX' is supported"
             )
 
-        print("FHP/MK hack using p1 PSF for ns in cuts")
-        indices = np.where(mask)[0]
-        col_1p = f"{self._prefix}_T_PSF_RECONV_1P"
-        new_psf = data[col_1p][indices]
-
-        # Overwriting incorrect no-shear PSF size to the one from 1p
-        ns["Tpsf"] = new_psf
-
         self.m1 = m1
         self.p1 = p1
         self.m2 = m2

--- a/src/sp_validation/tests/test_calibration.py
+++ b/src/sp_validation/tests/test_calibration.py
@@ -296,8 +296,8 @@ def test_metacal_R_matrix_recovers_injected_response():
     re-runs with slope 5.0 and confirms R11 tracks it (5.0 != 2.0), so a
     change that decouples R from the input numbers fails.
 
-    NOTE: the estimator prints an 'FHP/MK hack' line and an unweighted /
-    weighted response line; these are expected stdout, not errors.
+    NOTE: the estimator prints an unweighted / weighted response line; this
+    is expected stdout, not an error.
     """
     data, n = _build_ngmix_catalog(slope_11=2.0, slope_22=3.0, step=0.01)
     mask = np.ones(n, dtype=bool)


### PR DESCRIPTION
Closes #257.

Removes the vestigial **FHP/MK NOSHEAR←1P Tpsf substitution** from the two sites that carried it. This was a real workaround when written (`b076413`, Jan 2026) — for an older ShapePipe catalogue whose metacal no-shear reconvolution-PSF size was wrong, the code overwrote it with the 1P value in the galaxy size cut and mirrored the substitution onto the output column (keeping the original as `_NOSHEAR_orig`).

It is now a **no-op** under the current stack:

- **ngmix** builds one magnitude-dilated reconvolution PSF and reuses it for all metacal types (noshear literally reuses the 1p object) — the reconv-PSF size is identical across noshear/1p/1m/2p/2m by construction.
- **ShapePipe's ngmix module** fits that reconv PSF once per object and broadcasts the same scalar into all five per-type columns — so `_NOSHEAR` and `_1P` are bit-identical for every object.
- Confirmed empirically on the fiducial sim tile: the preserved `_orig` column is bit-identical to the hacked column.

### Changes
- **`calibration.py`** (`metacal._read_data`): drop the overwrite; the no-shear branch simply uses the `NGMIX_T_PSF_RECONV_NOSHEAR` column it already reads.
- **`scripts/calibration/calibrate_comprehensive_cat.py`**: drop the override and the now-redundant `NGMIX_T_PSF_RECONV_NOSHEAR_orig` column.
- **`test_calibration.py`**: update the estimator-stdout note (no `FHP/MK hack` line now).

> #257 proposed replacing the overwrite with an `assert_array_equal(NOSHEAR, 1P)` regression guard. On reflection we dropped that too: a consumer reading the no-shear PSF for the no-shear branch shouldn't police the producer's cross-column consistency (we don't for any other column), and the assert would *wrongly* crash if a future producer ever made the no-shear kernel genuinely distinct. From scratch, this code just reads the column it needs.

### Verification
No output changes under the current stack. `test_calibration.py` runs green in the container (8 passed).

**Note for downstream readers** (independent of this removal): the per-type `NGMIX_T_PSF_RECONV_<TYPE>` columns all carry the same object-level NOSHEAR-kernel value by design — the `_1P`/`_2P` labels are *not* physically distinct reconv-PSF measurements.

— Opus, on behalf of Cail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xthu9uZC17TsaeXh899fhc
