### PR TITLE
chore: remove vestigial pixel_size param (0.187)

### DIFF
--- a/scripts/calibration/params.py
+++ b/scripts/calibration/params.py
@@ -32,9 +32,6 @@ print("Field name = {}".format(name))
 ## Area of a tile in deg^2
 area_tile = 0.25
 
-## Pixel size in arcsec
-pixel_size = 0.187
-
 ## Shape measurement method (only 'ngmix' is supported):
 ##  'ngmix': multi-epoch model fitting
 shape = "ngmix"

--- a/workflow/image_sims/params_im_sim.py
+++ b/workflow/image_sims/params_im_sim.py
@@ -36,9 +36,6 @@ print("Field name = {}".format(name))
 ## Area of a tile in deg^2
 area_tile = 0.25
 
-## Pixel size in arcsec
-pixel_size = 0.187
-
 ## Shape measurement method, implemented is
 ##  'ngix': multi-epoch model fitting
 ##  'galsim': stacked-image moments (experimental)


### PR DESCRIPTION
## Summary

`pixel_size = 0.187` has no consumer. `git grep -n pixel_size` on `develop` finds only its two definitions:

```
scripts/calibration/params.py:36:pixel_size = 0.187
workflow/image_sims/params_im_sim.py:40:pixel_size = 0.187
```

No other file reads it. Its last consumer was removed in the `cs_util.size` migration (bfac233f).

Deleting beats correcting the value. Any future consumer should read the image WCS or the tile pixel scale (0.1857 for real tiles, 0.185 for sims). See UNIONS-WL/MultiBand_ImSim#2. A plausible-looking wrong constant left in place invites reuse.

Closes UNIONS-WL/MultiBand_ImSim#2

## Test plan

- [x] `git grep -n pixel_size` on develop confirmed no consumer before deleting
- Text-only change; no code path exercises this constant

— Fable, on behalf of Cail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hsz3vrQT6t21fWSj1cxcj

---
*Re-opened for review: #288 was merged prematurely; develop was reverted (f8d349e). This PR re-applies the identical change (revert of the revert).*