### PR TITLE
Bug in iNKA covariance

### DIFF
--- a/src/sp_validation/cosmo_val/pseudo_cl.py
+++ b/src/sp_validation/cosmo_val/pseudo_cl.py
@@ -224,7 +224,7 @@ class PseudoClMixin:
                     noise_bias_cl = self.get_noise_bias(params, nside, cat_gal_)
 
                     # If using the analytical noise bias, we need to decouple it
-                    if self.noise_bias_method == "analytical":
+                    if self.noise_bias_method == "analytic":
                         wsp = wsp_dict[f"W{bin_key1}xW{bin_key2}"]
                         noise_bias_cl = wsp.decouple_cell(noise_bias_cl)
 

--- a/src/sp_validation/cosmo_val/pseudo_cl.py
+++ b/src/sp_validation/cosmo_val/pseudo_cl.py
@@ -145,35 +145,14 @@ class PseudoClMixin:
             params = get_params_rho_tau(self.cc[ver])
             cat_gal = fits.getdata(self.cc[ver]["shear"]["path"])
 
-            for bin_key1, bin_key2 in tomo_bin_pairs:
-                if bin_key1 == bin_key2:
-                    cat_gal_ = self._get_tomographic_bin(params, cat_gal, bin_key1)
-
-                    noise_bias_cl = self.get_noise_bias(params, nside, cat_gal_)
-
-                else:
-                    noise_bias_cl = np.zeros((4, 2 * nside))
-
-                # Update the fiducial_cl dictionnary
-                fiducial_cl[f"W{bin_key1}xW{bin_key2}"] = (
-                    np.array(
-                        [
-                            fiducial_cl[f"W{bin_key1}xW{bin_key2}"],
-                            0.0 * fiducial_cl[f"W{bin_key1}xW{bin_key2}"],
-                            0.0 * fiducial_cl[f"W{bin_key1}xW{bin_key2}"],
-                            0.0 * fiducial_cl[f"W{bin_key1}xW{bin_key2}"],
-                        ]
-                    )
-                    + noise_bias_cl
-                )
+            lmin, lmax, b_lmax = spv_pseudo_cl.pseudo_cl_geometry(self.nside)
+            b = self.get_namaster_bin(lmin, lmax, b_lmax)
 
             # Compute the fields and workspaces
             for bin_key1, bin_key2 in tomo_bin_pairs:
                 self.print_cyan(
                     f"Computing fields and workspaces for {bin_key1}, {bin_key2}"
                 )
-                lmin, lmax, b_lmax = spv_pseudo_cl.pseudo_cl_geometry(self.nside)
-                b = self.get_namaster_bin(lmin, lmax, b_lmax)
 
                 # Get the tomographic bins
                 cat_gal_a = self._get_tomographic_bin(params, cat_gal, bin_key1)
@@ -233,6 +212,45 @@ class PseudoClMixin:
                     field_dict[f"W{bin_key2}"] = field_b
                 if bin_key1 <= bin_key2 and f"W{bin_key1}xW{bin_key2}" not in wsp_dict:
                     wsp_dict[f"W{bin_key1}xW{bin_key2}"] = wsp
+
+            for bin_key1, bin_key2 in tomo_bin_pairs:
+                if bin_key1 == bin_key2:
+                    self.print_cyan(
+                        f"Adding the noise bias for tomographic bins {bin_key1}, {bin_key2}"
+                    )
+
+                    cat_gal_ = self._get_tomographic_bin(params, cat_gal, bin_key1)
+
+                    noise_bias_cl = self.get_noise_bias(params, nside, cat_gal_)
+
+                    # If using the analytical noise bias, we need to decouple it
+                    if self.noise_bias_method == "analytical":
+                        wsp = wsp_dict[f"W{bin_key1}xW{bin_key2}"]
+                        noise_bias_cl = wsp.decouple_cell(noise_bias_cl)
+
+                        # And then unbin it
+                        noise_bias_cl = b.unbin_cell(noise_bias_cl)
+
+                        # Force the bins not part of the mask to be zero
+                        lowest_ell = b.get_ell_list(0)[0]
+                        for i in range(4):
+                            noise_bias_cl[i, :lowest_ell] = 0
+
+                else:
+                    noise_bias_cl = np.zeros((4, 2 * nside))
+
+                # Update the fiducial_cl dictionnary
+                fiducial_cl[f"W{bin_key1}xW{bin_key2}"] = (
+                    np.array(
+                        [
+                            fiducial_cl[f"W{bin_key1}xW{bin_key2}"],
+                            0.0 * fiducial_cl[f"W{bin_key1}xW{bin_key2}"],
+                            0.0 * fiducial_cl[f"W{bin_key1}xW{bin_key2}"],
+                            0.0 * fiducial_cl[f"W{bin_key1}xW{bin_key2}"],
+                        ]
+                    )
+                    + noise_bias_cl
+                )
 
             if self.fiducial_input_inka == "coupled":
                 # Couple the cell if required

--- a/src/sp_validation/cosmo_val/pseudo_cl.py
+++ b/src/sp_validation/cosmo_val/pseudo_cl.py
@@ -225,6 +225,9 @@ class PseudoClMixin:
 
                     # If using the analytical noise bias, we need to decouple it
                     if self.noise_bias_method == "analytic":
+                        self.print_cyan(
+                            "Decoupling the noise bias for the analytic method..."
+                        )
                         wsp = wsp_dict[f"W{bin_key1}xW{bin_key2}"]
                         noise_bias_cl = wsp.decouple_cell(noise_bias_cl)
 

--- a/src/sp_validation/cosmo_val/pseudo_cl.py
+++ b/src/sp_validation/cosmo_val/pseudo_cl.py
@@ -137,6 +137,13 @@ class PseudoClMixin:
 
             fiducial_cl = self.get_fiducial_cl(ver, compute_tomography)
 
+            # Add a zero multipole and drop the last value to align
+            # Namaster and fiducial binning
+            fiducial_cl = {
+                key: np.concatenate(([0.0], np.asarray(value[:-1], dtype=float)))
+                for key, value in fiducial_cl.items()
+            }
+
             self.print_cyan(
                 "Estimating and adding the noise bias to the fiducial power spectra"
             )


### PR DESCRIPTION
Related to Issue #290 , this PR fixes a bug in the iNKA covariance. The analytical based noise bias computation was missing a decoupling step leading to a misestimated noise bias and likely larger error bars. The updated functions is running for cross-validation with Gaussian simulations from #286 .

Ready to be merge as soon as the cross-validation is performed. In the meantime, design and runtime review is welcomed.