### PR TITLE
Residual-star plot: HSM_M4_* column names

### DIFF
--- a/papers/catalog/2025_12_09_residual_star_plot.py
+++ b/papers/catalog/2025_12_09_residual_star_plot.py
@@ -33,10 +33,10 @@ T_star = cat_star["HSM_T_STAR"]
 e1_psf = cat_star["HSM_G1_PSF"]
 e2_psf = cat_star["HSM_G2_PSF"]
 T_psf = cat_star["HSM_T_PSF"]
-M_4_1_star = cat_star["M_4_STAR_1"]
-M_4_2_star = cat_star["M_4_STAR_2"]
-M_4_1_psf = cat_star["M_4_PSF_1"]
-M_4_2_psf = cat_star["M_4_PSF_2"]
+M_4_1_star = cat_star["HSM_M4_1_STAR"]
+M_4_2_star = cat_star["HSM_M4_2_STAR"]
+M_4_1_psf = cat_star["HSM_M4_1_PSF"]
+M_4_2_psf = cat_star["HSM_M4_2_PSF"]
 
 # %%
 histtype = "step"


### PR DESCRIPTION
Closes #292.

Four one-line renames in `papers/catalog/2025_12_09_residual_star_plot.py`: the fourth-moment column reads move from the moment4-era names (`M_4_STAR_1`, …) to the `HSM_M4_*` grammar written by CosmoStat/shapepipe#859. The file's g/T reads already use the `HSM_` grammar. No other reader of the old names exists in this repo.

Note: the columns only exist in catalogues produced with shapepipe#859 (itself based on shapepipe#812), so this PR is inert until those merge and a run produces them — but the old names never existed in any shipped catalogue either (shapepipe#698 was never merged), so there is nothing to stay compatible with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K98geWHTuT62whqjKocfCm